### PR TITLE
Move ClusterRoleBinding to k8s-yml-generate

### DIFF
--- a/install_scripts/app.py
+++ b/install_scripts/app.py
@@ -386,6 +386,7 @@ def get_replicated_kubernetes(replicated_channel=None,
     storage_class = helpers.get_arg('storage_class', 'default')
     host_path_provisioner = helpers.get_arg('host_path_provisioner', 1)
     service_type = helpers.get_arg('service_type', 'NodePort')
+    kubernetes_namespace = helpers.get_arg('kubernetes_namespace', 'default')
 
     custom_selinux_replicated_domain = False
     selinux_replicated_domain = helpers.get_arg('selinux_replicated_domain',
@@ -409,6 +410,7 @@ def get_replicated_kubernetes(replicated_channel=None,
             storage_class=storage_class,
             host_path_provisioner=host_path_provisioner,
             service_type=service_type,
+            kubernetes_namespace=kubernetes_namespace,
             custom_selinux_replicated_domain=custom_selinux_replicated_domain,
             selinux_replicated_domain=selinux_replicated_domain,
             customer_base_url_override=customer_base_url, ))

--- a/install_scripts/templates/kubernetes-init.sh
+++ b/install_scripts/templates/kubernetes-init.sh
@@ -171,50 +171,7 @@ untaintMaster() {
         echo "Taint not found or already removed. The above error can be ignored."
     logSuccess "master taint removed"
 }
-
-createServiceAccount() {
-    logStep "create service account"
-    echo '---
-apiVersion: v1
-kind: List
-items:
-  - metadata:
-      labels:
-        name: replicated
-      name: replicated
-    apiVersion: v1
-    kind: ServiceAccount
-  - metadata:
-      labels:
-        name: replicated
-      name: replicated
-      namespace: kube-system
-    apiVersion: v1
-    kind: ServiceAccount
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
-    kind: ClusterRoleBinding
-    metadata:
-      name: replicated-admin
-      namespace: default
-    roleRef:
-      kind: ClusterRole
-      name: cluster-admin
-      apiGroup: rbac.authorization.k8s.io
-    subjects:
-      - kind: ServiceAccount
-        name: replicated
-        namespace: default
-      - kind: ServiceAccount
-        name: replicated
-        namespace: kube-system
-      - kind: ServiceAccount
-        name: default
-        namespace: default
-      - kind: ServiceAccount
-        name: default
-        namespace: kube-system' | kubectl apply -f -
-    logSuccess "service account"
-}
+ 
 kubernetesDeploy() {
     logStep "deploy replicated components"
 
@@ -431,7 +388,6 @@ logSuccess "Cluster Initialized"
 
 weavenetDeploy
 
-createServiceAccount
 untaintMaster
 
 spinnerNodeReady
@@ -446,7 +402,6 @@ kubectl get pods -n kube-system
 logSuccess "Kubernetes system"
 echo
 
-createServiceAccount
 kubernetesDeploy
 spinnerReplicatedReady
 

--- a/install_scripts/templates/kubernetes-yml-generate.sh
+++ b/install_scripts/templates/kubernetes-yml-generate.sh
@@ -66,6 +66,20 @@ while [ "$1" != "" ]; do
 done
 
 cat <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: replicated-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -84,7 +98,6 @@ spec:
         app: replicated
         tier: master
     spec:
-      serviceAccountName: default
       containers:
       - name: replicated
         image: "{{ replicated_docker_host }}/replicated/replicated:{{ replicated_tag }}{{ environment_tag_suffix }}"

--- a/install_scripts/templates/kubernetes-yml-generate.sh
+++ b/install_scripts/templates/kubernetes-yml-generate.sh
@@ -16,6 +16,7 @@ USER_ID=
 STORAGE_CLASS="{{ storage_class }}"
 HOST_PATH_PROVISIONER="{{ host_path_provisioner }}"
 SERVICE_TYPE="{{ service_type }}"
+KUBERNETES_NAMESPACE="{{ kubernetes_namespace }}"
 
 while [ "$1" != "" ]; do
     _param="$(echo "$1" | cut -d= -f1)"
@@ -70,7 +71,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: replicated-admin
-  namespace: default
+  namespace: "$KUBERNETES_NAMESPACE"
 roleRef:
   kind: ClusterRole
   name: cluster-admin
@@ -78,7 +79,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: default
-    namespace: default
+    namespace: "$KUBERNETES_NAMESPACE"
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
No longer create Replicated service accounts in default and kube-system
namespace.

All environments have a default service account.