### PR TITLE
Always just say bash, don't get fancy with ${0}

### DIFF
--- a/install_scripts/templates/kubernetes-init.sh
+++ b/install_scripts/templates/kubernetes-init.sh
@@ -206,7 +206,7 @@ outro() {
     printf "\n"
     printf "\nTo access the cluster with kubectl, reload your shell:\n\n"
     printf "\n"
-    printf "${GREEN}    ${0} -l${NC}"
+    printf "${GREEN}    bash -l${NC}"
     printf "\n"
     printf "\n"
     printf "\nTo continue the installation, visit the following URL in your browser:\n\n"


### PR DESCRIPTION
If you run with 
```
curl ... | sudo bash
```
 then `${0}` is `bash`, as expected. If you run it with 
```
curl -o install.sh ...
bash install.sh
```
then `${0}` is `install.sh`, which is not what we want to instruct people to run.

This change makes it so we always just instruct folks to `bash -l`, regardless of their shell, which should be fine for pretty much every case.