### PR TITLE
always start/enable kubelet, even if we skipped package install

### DIFF
--- a/install_scripts/templates/common/kubernetes.sh
+++ b/install_scripts/templates/common/kubernetes.sh
@@ -115,7 +115,6 @@ installComponentsApt() {
         dpkg -i --force-depends-version *.deb
     popd
     rm -rf archives
-    systemctl enable kubelet && systemctl start kubelet
 
     logSuccess "Kubernetes components installed"
 }
@@ -226,7 +225,6 @@ EOF
         yum install -y -q *.rpm
     popd
     rm -rf archives
-    systemctl enable kubelet && systemctl start kubelet
     logSuccess "Kubernetes components downloaded"
 }
 

--- a/install_scripts/templates/kubernetes-init.sh
+++ b/install_scripts/templates/kubernetes-init.sh
@@ -334,6 +334,7 @@ if [ "$RESTART_DOCKER" = "1" ]; then
 fi
 
 installKubernetesComponents
+systemctl enable kubelet && systemctl start kubelet
 
 if [ "$AIRGAP" = "1" ]; then
     logStep "Loading replicated and replicated-ui images from package\n"

--- a/install_scripts/templates/kubernetes-node-join.sh
+++ b/install_scripts/templates/kubernetes-node-join.sh
@@ -195,6 +195,7 @@ if ps aux | grep -qE "[k]ubelet"; then
 fi
 
 installKubernetesComponents
+systemctl enable kubelet && systemctl start kubelet
 
 promptForAddress
 promptForToken


### PR DESCRIPTION
I've confirmed that this is idempotent