### PR TITLE
Use RPM to install K8s packages

### DIFF
--- a/install_scripts/templates/common/kubernetes.sh
+++ b/install_scripts/templates/common/kubernetes.sh
@@ -222,7 +222,7 @@ EOF
       "replicated/k8s-packages:rhel-7-{{ kubernetes_version }}"
 
     pushd archives
-        yum install -y -q *.rpm
+        rpm --upgrade --force *.rpm
     popd
     rm -rf archives
     logSuccess "Kubernetes components downloaded"


### PR DESCRIPTION
This works for the first install and for subsequent installs, unlike yum
which reports "Error: nothing to do" for reinstalls.