### PR TITLE
specify server of registry image

### DIFF
--- a/bundles/k8s-containers-v1.9.3/mk-image-cache-lst
+++ b/bundles/k8s-containers-v1.9.3/mk-image-cache-lst
@@ -16,7 +16,7 @@ kube_dns_version=1.14.7
 pause_version=3.0
 etcd_version=3.1.11
 weave_version=2.2.0
-registry_version=2
+registry_version=2.6.2
 
 common="
 	$repo/kube-proxy-amd64:$kubernetes_version
@@ -27,7 +27,7 @@ common="
 	weaveworks/weave-kube:$weave_version
 	weaveworks/weave-npc:$weave_version
 	weaveworks/weaveexec:$weave_version
-	registry:$registry_version"
+	docker.io/registry:$registry_version"
 
 control="
 	$repo/kube-apiserver-amd64:$kubernetes_version


### PR DESCRIPTION
When linuxkit parses the reference for images in this repo it gets the
tag as the host/path and fails to get the digest. Prefixing the server
allows linuxkit to parse correctly and find the digest.