### PR TITLE
ignore the version of Docker specified for Amazon Linux

### DIFF
--- a/install_scripts/templates/common/docker-install.sh
+++ b/install_scripts/templates/common/docker-install.sh
@@ -128,25 +128,11 @@ _installDocker() {
 
     if [ "$LSB_DIST" = "amzn" ]; then
         # Docker install script no longer supports Amazon Linux
-        printf "${GREEN}Installing docker from Yum repository${NC}\n"
+        printf "${YELLOW}Pinning Docker version not supported on Amazon Linux${NC}\n"
+        printf "${GREEN}Installing Docker from Yum repository${NC}\n"
         
-        # 1.12.6, 17.03.2, 17.06.2 and 17.12.1ce are available
-        compareDockerVersions "17.12.0" "${1}"
-        if [ "$COMPARE_DOCKER_VERSIONS_RESULT" -eq "-1" ]; then
-            yum -y -q install docker-17.12.1ce
-        else
-            compareDockerVersions "17.06.0" "${1}"
-            if [ "$COMPARE_DOCKER_VERSIONS_RESULT" -eq "-1" ]; then
-                yum -y -q install docker-17.06.2ce
-            else
-                compareDockerVersions "17.3.0" "${1}"
-                if [ "$COMPARE_DOCKER_VERSIONS_RESULT" -eq "-1" ]; then
-                    yum -y -q install docker-17.03.2ce
-                else
-                    yum -y -q install docker-1.12.6
-                fi
-            fi
-        fi
+        yum -y -q install docker
+
         service docker start || true
         DID_INSTALL_DOCKER=1
         return


### PR DESCRIPTION
Amazon seems to be removing old Docker versions from their repos - at time of writing, only 17.12.1ce was available on Amazon Linux 18.03 or 17.09.

```
yum --showduplicates list docker
Available Packages
docker.x86_64  17.12.1ce-1.135.amzn1  amzn-main
```
