### PR TITLE
swarm join does not prompt for CA

### DIFF
--- a/install_scripts/templates/swarm-worker-join.sh
+++ b/install_scripts/templates/swarm-worker-join.sh
@@ -146,10 +146,10 @@ fi
 
 promptForSwarmToken
 
-promptForDaemonRegistryAddress
-mkdir -p "/etc/docker/certs.d/$DAEMON_REGISTRY_ADDRESS"
-promptForCA
-echo "$(echo "$CA" | base64 --decode)" > "/etc/docker/certs.d/$DAEMON_REGISTRY_ADDRESS/ca.crt"
+if [ -n "$DAEMON_REGISTRY_ADDRESS" ] && [ -n "$CA" ]; then
+    mkdir -p "/etc/docker/certs.d/$DAEMON_REGISTRY_ADDRESS"
+    echo "$(echo "$CA" | base64 --decode)" > "/etc/docker/certs.d/$DAEMON_REGISTRY_ADDRESS/ca.crt"
+fi
 
 echo "Joining the swarm"
 joinSwarm


### PR DESCRIPTION
Replicated versions greater than 2.20 generate scripts with the
daemon-registry-address and ca params set, so the CA will still be
written during install. When installing older pinned versions the CA
will not be set until later when the operator starts on the node.