### PR TITLE
poll until network is gone

### DIFF
--- a/install_scripts/templates/swarm-init.sh
+++ b/install_scripts/templates/swarm-init.sh
@@ -104,6 +104,9 @@ ensureReplicatedNetworkAttachable() {
         set -e
 
         docker network rm replicated_default
+        while $(docker network ls | grep --quiet "replicated_default"); do
+            sleep 1
+        done
     fi
 
     echo "Create attachable replicated_default network"


### PR DESCRIPTION
This follows removing the `replicated_default` network when upgrading Swarm from less than `2.22.0`.