### PR TITLE
Upstart service ensure prior container has been removed

### DIFF
--- a/install_scripts/templates/upstart/replicated-operator.conf
+++ b/install_scripts/templates/upstart/replicated-operator.conf
@@ -3,12 +3,19 @@ author "Replicated.com"
 start on replicated-docker or started docker
 stop on runlevel [!2345] or stopping docker
 respawn
-respawn limit 5 10
+respawn limit 5 30
 normal exit 0
 pre-start script
     /bin/mkdir -p /var/run/replicated-operator /var/lib/replicated-operator
     /bin/chown -R ${REPLICATED_USER_ID}:${DOCKER_GROUP_ID} /var/run/replicated-operator /var/lib/replicated-operator
     /usr/bin/docker rm -f replicated-operator 2>/dev/null || true
+    COUNTER=0
+    while $(/usr/bin/docker ps -a | grep --quiet "replicated-operator:current") && [ $COUNTER -lt 3 ]; do
+        #Try removing the container again, but don't suppress output this time
+        /usr/bin/docker rm -f replicated-operator || true
+        sleep 1
+        COUNTER=$(($COUNTER+1))
+    done
 end script
 pre-stop script
     /usr/bin/docker stop replicated-operator

--- a/install_scripts/templates/upstart/replicated-ui.conf
+++ b/install_scripts/templates/upstart/replicated-ui.conf
@@ -3,12 +3,19 @@ author "Replicated.com"
 start on replicated-docker or started docker
 stop on runlevel [!2345] or stopping docker
 respawn
-respawn limit 5 10
+respawn limit 5 30
 normal exit 0
 pre-start script
     /bin/mkdir -p /var/run/replicated
     /bin/chown -R ${REPLICATED_USER_ID}:${DOCKER_GROUP_ID} /var/run/replicated
     /usr/bin/docker rm -f replicated-ui 2>/dev/null || true
+    COUNTER=0
+    while $(/usr/bin/docker ps -a | grep --quiet "replicated-ui:current") && [ $COUNTER -lt 3 ]; do
+        #Try removing the container again, but don't suppress output this time
+        /usr/bin/docker rm -f replicated-ui || true
+        sleep 1
+        COUNTER=$(($COUNTER+1))
+    done
 end script
 pre-stop script
     /usr/bin/docker stop replicated-ui

--- a/install_scripts/templates/upstart/replicated.conf
+++ b/install_scripts/templates/upstart/replicated.conf
@@ -3,13 +3,20 @@ author "Replicated.com"
 start on replicated-docker or started docker
 stop on runlevel [!2345] or stopping docker
 respawn
-respawn limit 5 10
+respawn limit 5 30
 normal exit 0
 pre-start script
     /bin/mkdir -p /var/run/replicated /var/lib/replicated /var/lib/replicated/statsd {{ premkit_data_dir }}
     /bin/chown -R ${REPLICATED_USER_ID}:${DOCKER_GROUP_ID} /var/run/replicated /var/lib/replicated {{ premkit_data_dir }}
     /bin/chmod -R 755 /var/lib/replicated/tmp 2>/dev/null || true
     /usr/bin/docker rm -f replicated 2>/dev/null || true
+    COUNTER=0
+    while $(/usr/bin/docker ps -a | grep --quiet "replicated:current") && [ $COUNTER -lt 3 ]; do
+        #Try removing the container again, but don't suppress output this time
+        /usr/bin/docker rm -f replicated || true
+        sleep 1
+        COUNTER=$(($COUNTER+1))
+    done
 end script
 pre-stop script
     /usr/bin/docker stop replicated


### PR DESCRIPTION
To avoid "container name still in use" errors, confirm removal success as part of the pre-start script and retry a limited number of times upon failure. Retries should have standard error show in logs (first try does not due to the frequency of "container does not exist" errors)

increase upstart respawn limit timer to avoid infinite loops