### PR TITLE
install docker on bionic from xenial channel

### DIFF
--- a/install_scripts/templates/docker-install/17-03-ce.sh
+++ b/install_scripts/templates/docker-install/17-03-ce.sh
@@ -301,6 +301,10 @@ do_install() {
 			if [ -z "$dist_version" ] && [ -r /etc/lsb-release ]; then
 				dist_version="$(. /etc/lsb-release && echo "$DISTRIB_CODENAME")"
 			fi
+			# Since bionic stable doesn't have docker-ce < 18.06
+			if [ "$dist_version" = "bionic" ]; then
+				dist_version="xenial"
+			fi
 		;;
 
 		debian|raspbian)

--- a/install_scripts/templates/docker-install/17-06-ce.sh
+++ b/install_scripts/templates/docker-install/17-06-ce.sh
@@ -388,6 +388,10 @@ do_install() {
 			if [ -z "$dist_version" ] && [ -r /etc/lsb-release ]; then
 				dist_version="$(. /etc/lsb-release && echo "$DISTRIB_CODENAME")"
 			fi
+			# Since bionic stable doesn't have docker-ce < 18.06
+			if [ "$dist_version" = "bionic" ]; then
+				dist_version="xenial"
+			fi
 		;;
 
 		debian|raspbian)

--- a/install_scripts/templates/docker-install/17-12-ce.sh
+++ b/install_scripts/templates/docker-install/17-12-ce.sh
@@ -45,15 +45,19 @@ x86_64-debian-stretch
 x86_64-debian-buster
 x86_64-ubuntu-trusty
 x86_64-ubuntu-xenial
+x86_64-ubuntu-bionic
 x86_64-ubuntu-zesty
 x86_64-ubuntu-artful
 s390x-ubuntu-xenial
+s390x-ubuntu-bionic
 s390x-ubuntu-zesty
 s390x-ubuntu-artful
 ppc64le-ubuntu-xenial
+ppc64le-ubuntu-bionic
 ppc64le-ubuntu-zesty
 ppc64le-ubuntu-artful
 aarch64-ubuntu-xenial
+aarch64-ubuntu-bionic
 aarch64-ubuntu-zesty
 aarch64-debian-jessie
 aarch64-debian-stretch
@@ -66,6 +70,7 @@ armv7l-debian-stretch
 armv7l-debian-buster
 armv7l-ubuntu-trusty
 armv7l-ubuntu-xenial
+armv7l-ubuntu-bionic
 armv7l-ubuntu-zesty
 armv7l-ubuntu-artful
 "
@@ -315,6 +320,10 @@ do_install() {
 			fi
 			if [ -z "$dist_version" ] && [ -r /etc/lsb-release ]; then
 				dist_version="$(. /etc/lsb-release && echo "$DISTRIB_CODENAME")"
+			fi
+			# Since bionic stable doesn't have docker-ce < 18.06
+			if [ "$dist_version" = "bionic" ]; then
+				dist_version="xenial"
 			fi
 		;;
 


### PR DESCRIPTION
Docker is only available in bionic/edge channel at version 18.05.
Docker 17.03, 17.06, and 17.12 install on bionic from xenial channel,
but 1.12 and 1.13 do not work.