### PR TITLE
upgrade K8s clusters

### DIFF
--- a/bundles/k8s-rhel7/Dockerfile
+++ b/bundles/k8s-rhel7/Dockerfile
@@ -1,7 +1,12 @@
-FROM centos:7
+FROM centos:7.4.1708
+ARG VERSION
 COPY ./kubernetes.repo /etc/yum.repos.d/kubernetes.repo
 RUN mkdir -p /packages/archives
-RUN yumdownloader --resolve --destdir=/packages/archives -y kubelet kubeadm kubectl kubernetes-cni
+RUN yumdownloader --resolve --destdir=/packages/archives -y kubelet-$VERSION kubeadm-$VERSION kubectl-$VERSION kubernetes-cni
+
+# First upgrade step requires upgraded kubeadm binary before kubeadm package is upgraded
+# https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-11/
+RUN curl -sSL https://dl.k8s.io/release/v${VERSION}/bin/linux/amd64/kubeadm > /packages/archives/kubeadm
 
 FROM busybox:latest
 COPY --from=0 /packages /packages

--- a/bundles/k8s-rhel7/Makefile
+++ b/bundles/k8s-rhel7/Makefile
@@ -1,15 +1,16 @@
-build:
-	docker build -t quay.io/replicated/k8s-packages:rhel-7-v1.9.3 .
-	docker build -t quay.io/replicated/k8s-packages:rhel-7-v1.9.3.20180227 .
+DATE=$(shell date +%Y%m%d)
 
-push:
-	docker push quay.io/replicated/k8s-packages:rhel-7-v1.9.3
-	docker push quay.io/replicated/k8s-packages:rhel-7-v1.9.3.20180227
+v1.9.3:
+	docker build --build-arg VERSION=1.9.3 \
+		-t quay.io/replicated/k8s-packages:rhel-74-v1.9.3-${DATE} .
+	docker push quay.io/replicated/k8s-packages:rhel-74-v1.9.3-${DATE}
 
-export: build
-	docker tag quay.io/replicated/k8s-packages:rhel-7-v1.9.3 replicated/k8s-packages:rhel-7-v1.9.3
-	docker save replicated/k8s-packages:rhel-7-v1.9.3 > packages-kubernetes-rhel7.tar
+v1.10.5:
+	docker build --build-arg VERSION=1.10.5 \
+		-t quay.io/replicated/k8s-packages:rhel-74-v1.10.5-${DATE} .
+	docker push quay.io/replicated/k8s-packages:rhel-74-v1.10.5-${DATE}
 
-# this gets run by airgap install script
-unpack_example: build
-	docker run -v ${PWD}:/out quay.io/replicated/k8s-packages:rhel-7-v1.9.3
+v1.11.0:
+	docker build --build-arg VERSION=1.11.0 \
+		-t quay.io/replicated/k8s-packages:rhel-74-v1.11.0-${DATE} .
+	docker push quay.io/replicated/k8s-packages:rhel-74-v1.11.0-${DATE}

--- a/bundles/k8s-ubuntu1604/Dockerfile
+++ b/bundles/k8s-ubuntu1604/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:16.04
+ARG VERSION
 RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get -y install curl apt-transport-https
@@ -6,10 +7,13 @@ RUN mkdir -p /packages
 RUN  curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add
 COPY ./kubernetes.list /etc/apt/sources.list.d/kubernetes.list
 RUN apt-get update
-RUN apt-get install -d -y kubeadm=1.9.3-00 kubelet=1.9.3-00 kubectl=1.9.3-00 kubernetes-cni -oDebug::NoLocking=1 -o=dir::cache=/packages/
+RUN apt-get install -d -y kubeadm=${VERSION}-00 kubelet=${VERSION}-00 kubectl=${VERSION}-00 kubernetes-cni -oDebug::NoLocking=1 -o=dir::cache=/packages/
+
+# First upgrade step requires upgraded kubeadm binary before kubeadm package is upgraded
+# https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-11/
+RUN curl -sSL https://dl.k8s.io/release/v${VERSION}/bin/linux/amd64/kubeadm > /packages/archives/kubeadm
 
 
 FROM busybox:latest
 COPY --from=0 /packages /packages
 CMD cp -r /packages/* /out/
-

--- a/bundles/k8s-ubuntu1604/Makefile
+++ b/bundles/k8s-ubuntu1604/Makefile
@@ -1,11 +1,16 @@
-build:
-	docker build -t quay.io/replicated/k8s-packages:ubuntu-1604-v1.9.3 .
-	docker build -t quay.io/replicated/k8s-packages:ubuntu-1604-v1.9.3.20180416 .
+DATE=$(shell date +%Y%m%d)
 
-push:
-	docker push quay.io/replicated/k8s-packages:ubuntu-1604-v1.9.3
-	docker push quay.io/replicated/k8s-packages:ubuntu-1604-v1.9.3.20180416
+v1.9.3:
+	docker build --build-arg VERSION=1.9.3 \
+		-t quay.io/replicated/k8s-packages:ubuntu-1604-v1.9.3-${DATE} .
+	docker push quay.io/replicated/k8s-packages:ubuntu-1604-v1.9.3-${DATE}
 
-# this gets run by airgap install script
-unpack_example:
-	docker run -v ${PWD}:/out replicated/k8s-packages:ubuntu-1604-v1.9.3
+v1.10.5:
+	docker build --build-arg VERSION=1.10.5 \
+		-t quay.io/replicated/k8s-packages:ubuntu-1604-v1.10.5-${DATE} .
+	docker push quay.io/replicated/k8s-packages:ubuntu-1604-v1.10.5-${DATE}
+
+v1.11.0:
+	docker build --build-arg VERSION=1.11.0 \
+		-t quay.io/replicated/k8s-packages:ubuntu-1604-v1.11.0-${DATE} .
+	docker push quay.io/replicated/k8s-packages:ubuntu-1604-v1.11.0-${DATE}

--- a/install_scripts/app.py
+++ b/install_scripts/app.py
@@ -548,6 +548,22 @@ def get_swarm_init_worker(replicated_channel=None,
     return Response(response, mimetype='text/x-shellscript')
 
 
+@app.route('/kubernetes-upgrade')
+@app.route('/kubernetes-upgrade.sh')
+def get_kubernetes_upgrade_master():
+    response = render_template(
+        'kubernetes-upgrade.sh',
+        **helpers.template_args())
+    return Response(response, mimetype='text/x-shellscript')
+
+@app.route('/kubernetes-node-upgrade')
+@app.route('/kubernetes-node-upgrade.sh')
+def get_kubernetes_upgrade_worker():
+    response = render_template(
+        'kubernetes-node-upgrade.sh',
+        **helpers.template_args())
+    return Response(response, mimetype='text/x-shellscript')
+
 @app.route('/kubernetes-init')
 @app.route('/kubernetes-init.sh')
 @app.route('/<replicated_channel>/kubernetes-init')

--- a/install_scripts/templates/kubernetes-init.sh
+++ b/install_scripts/templates/kubernetes-init.sh
@@ -90,7 +90,6 @@ EOF
 getKubeServerVersion() {
     logStep "check k8s server version"
     # poll until we can get the current server version
-    _current="$(kubectl version -o yaml | grep gitVersion | cut -d" " -f4)"
     _current="$(kubectl version | grep 'Server Version' | tr " " "\n" | grep GitVersion | cut -d'"' -f2)"
     until [ -n "$_current" ]; do
       _current="$(kubectl version | grep 'Server Version' | tr " " "\n" | grep GitVersion | cut -d'"' -f2)"

--- a/install_scripts/templates/kubernetes-init.sh
+++ b/install_scripts/templates/kubernetes-init.sh
@@ -322,7 +322,6 @@ outroKubeadm() {
         printf "\nTo add nodes to this installation, copy and unpack this bundle on your other nodes, and run the following:"
         printf "\n"
         printf "\n"
-        # This cut -d works in 1.9.3, we will need to test again in later kubeadm versions. Once phases are out of alpha lets use those
         printf "${GREEN}    cat ./kubernetes-node-join.sh  | sudo bash -s kubernetes-master-address=${PRIVATE_ADDRESS} kubeadm-token=${BOOTSTRAP_TOKEN} kubeadm-token-ca-hash=$KUBEADM_TOKEN_CA_HASH \n"
         printf "${NC}"
         printf "\n"
@@ -513,7 +512,7 @@ if [ "$NO_PROXY" != "1" ] && [ -n "$PROXY_ADDRESS" ]; then
     checkDockerProxyConfig
 fi
 
-installKubernetesComponents
+installKubernetesComponents "$KUBERNETES_VERSION"
 if [ "$CLUSTER_DNS" != "$DEFAULT_CLUSTER_DNS" ]; then
     sed -i "s/$DEFAULT_CLUSTER_DNS/$CLUSTER_DNS/g" /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 fi
@@ -541,7 +540,7 @@ weavenetDeploy
 
 untaintMaster
 
-spinnerNodeReady
+spinnerMasterNodeReady
 
 echo
 kubectl get nodes

--- a/install_scripts/templates/kubernetes-node-join.sh
+++ b/install_scripts/templates/kubernetes-node-join.sh
@@ -12,6 +12,7 @@ NO_CE_ON_EE="{{ no_ce_on_ee }}"
 HARD_FAIL_ON_LOOPBACK="{{ hard_fail_on_loopback }}"
 KUBERNETES_ONLY=0
 ADDITIONAL_NO_PROXY=
+KUBERNETES_VERSION="{{ kubernetes_version }}"
 
 {% include 'common/common.sh' %}
 {% include 'common/prompt.sh' %}
@@ -229,7 +230,7 @@ if ps aux | grep -qE "[k]ubelet"; then
     exit 0
 fi
 
-installKubernetesComponents
+installKubernetesComponents "$KUBERNETES_VERSION"
 systemctl enable kubelet && systemctl start kubelet
 
 if [ "$AIRGAP" = "1" ]; then

--- a/install_scripts/templates/kubernetes-node-upgrade.sh
+++ b/install_scripts/templates/kubernetes-node-upgrade.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -e
+AIRGAP=0
+
+{% include 'common/common.sh' %}
+{% include 'common/kubernetes.sh' %}
+{% include 'common/log.sh' %}
+{% include 'common/system.sh' %}
+
+#######################################
+# Upgrade Kubernetes on worker node
+# Globals:
+#   LSB_DIST
+#   DIST_VERSION
+# Arguments:
+#   k8sVersion - e.g. v1.10.5
+# Returns:
+#   None
+#######################################
+upgradeK8sNode() {
+    k8sVersion=$1
+    pkgTag=$(k8sPackageTag $k8sVersion)
+
+    echo "Upgrading node to Kubernetes $k8sVersion"
+
+    if [ "$AIRGAP" = "1" ]; then
+        docker load < packages-kubernetes-${pkgTag}
+    fi
+    docker run \
+      -v $PWD:/out \
+      "quay.io/replicated/k8s-packages:${pkgTag}"
+
+
+    case "$LSB_DIST$DIST_VERSION" in
+        ubuntu16.04)
+            export DEBIAN_FRONTEND=noninteractive
+            dpkg -i archives/*.deb
+            ;;
+        centos7.4|rhel7.*)
+            rpm --upgrade --force archives/*.rpm
+            ;;
+        *)
+            bail "Unsuported OS: $LSB_DIST$DIST_VERSION"
+            ;;
+    esac
+
+    rm -rf archives
+
+    systemctl daemon-reload
+    systemctl restart kubelet
+}
+
+################################################################################
+# Execution starts here
+################################################################################
+
+require64Bit
+requireRootUser
+detectLsbDist
+bailIfUnsupportedOS
+
+while [ "$1" != "" ]; do
+    _param="$(echo "$1" | cut -d= -f1)"
+    _value="$(echo "$1" | grep '=' | cut -d= -f2-)"
+    case $_param in
+        airgap)
+            AIRGAP=1
+            ;;
+        kubernetes-version|kubernetes_version)
+            K8S_VERSION=${_value}
+            ;;
+        *)
+            echo >&2 "Error: unknown parameter \"$_param\""
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$K8S_VERSION" ]; then
+    bail "kubernetes-version is required"
+fi
+
+upgradeK8sNode $K8S_VERSION
+
+# not supportted in kubeadm < 1.11
+kubeadm upgrade node config --kubelet-version $(kubelet --version | cut -d ' ' -f 2) 2>/dev/null || :
+
+systemctl restart kubelet
+
+printf "\n"
+printf "\t\t${GREEN} Node Upgrade Complete ✔${NC}\n"
+printf "\n"

--- a/install_scripts/templates/kubernetes-upgrade.sh
+++ b/install_scripts/templates/kubernetes-upgrade.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+set -e
+AIRGAP=0
+
+{% include 'common/common.sh' %}
+{% include 'common/kubernetes.sh' %}
+{% include 'common/log.sh' %}
+{% include 'common/prompt.sh' %}
+{% include 'common/system.sh' %}
+
+#######################################
+# Upgrade Kubernetes on remote workers to master version
+# Globals:
+#   AIRGAP
+# Arguments:
+#   None
+# Returns:
+#   None
+#######################################
+upgradeK8sWorkers() {
+    masterVersion=$(getK8sMasterVersion)
+    version="v${masterVersion}"
+
+    workers=$(kubectl get nodes | sed '1d' | grep -v master | grep -v $version | awk '{ print $1 }')
+
+    for node in $workers; do
+        kubectl drain "$node" --ignore-daemonsets --delete-local-data --force
+        printf "\n\n\tRun the upgrade script on remote node before proceeding: ${GREEN}$node${NC}\n\n"
+        if [ "$AIRGAP" = "1" ]; then
+            printf "\t${GREEN}cat kubernetes-node-upgrade | sudo bash -s kubernetes-version=$version${NC}"
+        else
+            printf "\t${GREEN}curl https://get.replicated.com/kubernetes-node-upgrade | sudo bash -s kubernetes-version=$version${NC}"
+        fi
+        printf "\n\n\tContinue when script has completed\n\n"
+        prompt
+        kubectl uncordon $node
+    done
+
+    spinnerNodesReady
+}
+
+#######################################
+# Upgrade Kubernetes on master node
+# Globals:
+#   LSB_DIST
+#   DIST_VERSION
+# Arguments:
+#   k8sVersion - e.g. v1.10.5
+# Returns:
+#   None
+#######################################
+upgradeK8sMaster() {
+    k8sVersion=$1
+    pkgTag=$(k8sPackageTag $k8sVersion)
+
+    if [ "$AIRGAP" = "1" ]; then
+        docker load < packages-kubernetes-${pkgTag}
+    fi
+    docker run \
+      -v $PWD:/out \
+      "quay.io/replicated/k8s-packages:${pkgTag}"
+
+    # must use kubeadm binary to begin upgrade before upgrading kubeadm package
+    # https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-11/
+    cp archives/kubeadm /usr/bin/kubeadm
+    chmod a+rx /usr/bin/kubeadm
+
+    # The coredns deployment sets allowPrivilegeEscalation: false, which causes
+    # a crash loop backoff if SELinux is enabled, which is common for CentOS
+    # even if it has been set to permissive mode. Required policy would be:
+    # typebounds container_runtime_t svirt_lxc_net_t;
+    kubeadm upgrade apply $k8sVersion --yes \
+        --config=/opt/replicated/kubeadm.conf \
+        --feature-gates=CoreDNS=false
+
+    # upgrade master
+    master=$(kubectl get nodes | grep master | awk '{ print $1 }')
+    # ignore error about unmanaged pods
+    kubectl drain $master --ignore-daemonsets --delete-local-data 2>/dev/null || :
+
+    case "$LSB_DIST$DIST_VERSION" in
+        ubuntu16.04)
+            export DEBIAN_FRONTEND=noninteractive
+            dpkg -i archives/*.deb
+            ;;
+        centos7.4|rhel7.*)
+            rpm --upgrade --force archives/*.rpm
+            ;;
+        *)
+            bail "Unsuported OS: $LSB_DIST$DIST_VERSION"
+            ;;
+    esac
+
+    rm -rf archives
+
+    systemctl daemon-reload
+    systemctl restart kubelet
+
+    kubectl uncordon $master
+
+    sed -i "s/kubernetesVersion:.*/kubernetesVersion: $k8sVersion/" /opt/replicated/kubeadm.conf
+    
+    spinnerNodesReady
+}
+
+#######################################
+# Get k8s master version
+# Globals:
+#   None
+# Arguments:
+#   None
+# Returns:
+#   version - e.g. 1.9.3
+#######################################
+getK8sMasterVersion() {
+    echo $(kubectl get nodes | grep master | awk '{ print $5 }' | sed 's/v//')
+}
+
+################################################################################
+# Execution starts here
+################################################################################
+
+require64Bit
+requireRootUser
+detectLsbDist
+bailIfUnsupportedOS
+
+while [ "$1" != "" ]; do
+    _param="$(echo "$1" | cut -d= -f1)"
+    _value="$(echo "$1" | grep '=' | cut -d= -f2-)"
+    case $_param in
+        airgap)
+            AIRGAP=1
+            ;;
+        *)
+            echo >&2 "Error: unknown parameter \"$_param\""
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+export KUBECONFIG=/etc/kubernetes/admin.conf
+
+semverParse $(getK8sMasterVersion)
+
+if [ "$major" -eq 1 ] && [ "$minor" -eq 9 ]; then
+    upgradeK8sMaster v1.10.5 $UBUNTU_1604_K8S_10 $CENTOS_74_K8S_10
+fi
+
+upgradeK8sWorkers
+
+semverParse $(getK8sMasterVersion)
+
+if [ "$major" -eq 1 ] && [ "$minor" -eq 10 ]; then
+    upgradeK8sMaster v1.11.0 $UBUNTU_1604_K8S_11 $CENTOS_74_K8S_11
+fi
+
+upgradeK8sWorkers
+
+printf "\n"
+printf "\t\t${GREEN} Upgrade Complete ✔${NC}\n"
+printf "\n"


### PR DESCRIPTION
    upgrade K8s clusters to v1.11.0

    This attempts to follow best practices from
    https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-11/.

    kubeadm upgrades cannot skip a minor version so upgrading to 1.10.5 must
    be completed as the first step before upgrading to 1.11.0.

    CoreDNS is not included because of SELinux incompatibilities introduced
    in https://github.com/kubernetes/kubernetes/pull/64473/files.

    This does not update Replicated to a version compatible with K8s
    v1.11.0. The kubernetes-upgrade.sh script should probably be merged with
    the kubernetes-init.sh script to accomplish that.

    Untested on airgap.
