### PR TITLE
remove replicated_channel route on root to catch misspelled routes

### DIFF
--- a/install_scripts/app.py
+++ b/install_scripts/app.py
@@ -68,10 +68,8 @@ def get_replicated_version(replicated_channel=None,
 
 
 @app.route('/')
-@app.route('/<replicated_channel>')
-def get_replicated_one_point_two(replicated_channel=None):
-    replicated_channel = replicated_channel if replicated_channel else 'stable'
-    kwargs = helpers.template_args(channel_name=replicated_channel)
+def catch_all():
+    kwargs = helpers.template_args(channel_name='stable')
     kwargs['pinned_docker_version'] = '1.12.3'
     response = render_template('replicated-1.2.sh', **kwargs)
     return Response(response, mimetype='text/x-shellscript')


### PR DESCRIPTION
This fixes the problem where installer commands with route misspellings, i.e., `curl https://get.replicated.com/dockr | sudo bash` (note 'dockr') would return the replicated 1.2 install script instead of a nice 'Not Found' error.

I did this by removing the chained `@app.route('/<replicated_channel>')`. Now, misspelled routes will return a nice 'Not Found' error while the empty route, i.e., `curl https://get.replicated.com/ | sudo bash` will still return the replicated 1.2 install script.