### PR TITLE
K8s upgrade bug fixes

### DIFF
--- a/install_scripts/templates/common/kubernetes.sh
+++ b/install_scripts/templates/common/kubernetes.sh
@@ -161,7 +161,7 @@ installKubernetesComponents() {
             sysctl --system
             service docker restart
 
-            rpm --upgrade --force archives/*.rpm
+            rpm --upgrade --force --nodeps archives/*.rpm
             service docker restart
             ;;
 
@@ -289,7 +289,6 @@ airgapLoadKubernetesControlImages() {
             ;;
     esac
 
-    docker images | grep google_containers
     logSuccess "control plane images"
 
     logStep "replicated addons"
@@ -317,7 +316,7 @@ airgapLoadKubernetesControlImages1106() {
     docker tag 6e29896cbeca k8s.gcr.io/kube-apiserver-amd64:v1.10.6
     docker tag dd246160bf59 k8s.gcr.io/kube-scheduler-amd64:v1.10.6
     docker tag 3224e7c2de11 k8s.gcr.io/kube-controller-manager-amd64:v1.10.6
-    docker tag 52920ad46f5b k8s.gcr.io/etcd-amd64:v3.1.12
+    docker tag 52920ad46f5b k8s.gcr.io/etcd-amd64:3.1.12
 }
 
 airgapLoadKubernetesControlImages1111() {

--- a/install_scripts/templates/kubernetes/init.sh
+++ b/install_scripts/templates/kubernetes/init.sh
@@ -184,6 +184,9 @@ getYAMLOpts() {
     if [ "$ENCRYPT_NETWORK" = "0" ]; then
         opts=$opts" encrypt-network=0"
     fi
+    if KUBECONFIG=/etc/kubernetes/admin.conf kubectl get storageclass | grep rook.io > /dev/null ; then
+        opts=$opts" storage-provisioner=0"
+    fi
     YAML_GENERATE_OPTS="$opts"
 }
 

--- a/install_scripts/templates/kubernetes/node-upgrade.sh
+++ b/install_scripts/templates/kubernetes/node-upgrade.sh
@@ -44,4 +44,11 @@ maybeUpgradeKubernetesNode "$KUBERNETES_VERSION"
 
 if [ "$AIRGAP" = "1" ]; then
     airgapLoadKubernetesCommonImages "$KUBERNETES_VERSION"
+
+    # When the master upgrades to 1.11.1 it may try to schedule coreDNS pods on
+    # this node and will hang until they start, so we need to preload those
+    # images. Need to figure this out for future upgrades.
+    if [ "$KUBERNETES_VERSION" = "1.10.6" ]; then
+        airgapLoadKubernetesCommonImages 1.11.1
+    fi
 fi

--- a/install_scripts/templates/kubernetes/yml-generate.sh
+++ b/install_scripts/templates/kubernetes/yml-generate.sh
@@ -890,8 +890,8 @@ spec:
       databaseSizeMB: "1024" # this value can be removed for environments with normal sized disks (100 GB or larger)
       journalSizeMB: "1024"  # this value can be removed for environments with normal sized disks (20 GB or larger)
 # Cluster level list of directories to use for storage. These values will be set for all nodes that have no `directories` set.
-#    directories:
-#    - path: "$PV_BASE_PATH"
+     directories:
+     - path: "$PV_BASE_PATH"
 ---
 apiVersion: ceph.rook.io/v1beta1
 kind: Pool
@@ -906,27 +906,6 @@ spec:
   # For a pool based on raw copies, specify the number of copies. A size of 1 indicates no redundancy.
   replicated:
     size: 1
----
-# ceph dashboard service
-apiVersion: v1
-kind: Service
-metadata:
-  name: rook-ceph-mgr-dashboard-external
-  namespace: rook-ceph
-  labels:
-    app: rook-ceph-mgr
-    rook_cluster: rook-ceph
-spec:
-  ports:
-  - name: dashboard
-    port: 7000
-    protocol: TCP
-    targetPort: 7000
-  selector:
-    app: rook-ceph-mgr
-    rook_cluster: rook-ceph
-  sessionAffinity: None
-  type: NodePort
 EOF
 }
 


### PR DESCRIPTION
Don't publish the dashboard.
Don't grep for google_containers.
Uncomment rook data path.
Fix airgap 1.10.6 images.
Fix upgrade worker airgap bugs.
Preload 1.11.1 on worker for coredns images.
Don't reapply storage class if it exists.