### PR TITLE
Replicated PVC 100G for airgap installs

### DIFF
--- a/install_scripts/templates/common/kubernetes.sh
+++ b/install_scripts/templates/common/kubernetes.sh
@@ -697,5 +697,5 @@ k8s_reset() {
     rm -rf /var/lib/replicated
     rm -rf /var/lib/etcd
     rm -f /usr/bin/kubeadm /usr/bin/kubelet /usr/bin/kubectl
-    kill $(ps aux | grep '[k]ubelet' | awk '{print $2}')
+    kill $(ps aux | grep '[k]ubelet' | awk '{print $2}') 2> /dev/null
 }

--- a/install_scripts/templates/kubernetes/init.sh
+++ b/install_scripts/templates/kubernetes/init.sh
@@ -187,6 +187,9 @@ getYAMLOpts() {
     if KUBECONFIG=/etc/kubernetes/admin.conf kubectl get storageclass | grep rook.io > /dev/null ; then
         opts=$opts" storage-provisioner=0"
     fi
+    if KUBECONFIG=/etc/kubernetes/admin.conf kubectl get pvc | grep replicated-pv-claim > /dev/null ; then
+        opts=$opts" replicated-pvc=0"
+    fi
     YAML_GENERATE_OPTS="$opts"
 }
 


### PR DESCRIPTION
Since this script may be run to upgrade existing airgap installs and the
size of exiting PVCs provisioned by Rook cannot be edited, include a
check to disable rendering the Replicated PVC yaml it the resource
already exists.