### PR TITLE
pass k8s version to kubeadm init

### DIFF
--- a/install_scripts/templates/common/kubernetes-upgrade.sh
+++ b/install_scripts/templates/common/kubernetes-upgrade.sh
@@ -85,7 +85,15 @@ maybeUpgradeKubernetesNode() {
         if [ "$upgradeMinor" -gt 10 ]; then
             touch /tmp/config.yaml
             kubeadm alpha phase kubelet write-env-file --config=/tmp/config.yaml
-            kubeadm upgrade node config --kubelet-version $(kubelet --version | cut -d ' ' -f 2)
+            local n=0
+            local ver=$(kubelet --version | cut -d ' ' -f 2)
+            while ! kubeadm upgrade node config --kubelet-version "$ver" ; do
+                n="$(( $n + 1 ))"
+                if [ "$n" -ge "10" ]; then
+                    exit 1
+                fi
+                sleep 2
+            done
         fi
 
         systemctl restart kubelet

--- a/install_scripts/templates/kubernetes/init.sh
+++ b/install_scripts/templates/kubernetes/init.sh
@@ -96,15 +96,19 @@ initKube() {
         initKubeadmConfig
         set +e
 
-        if [ "$(kubeadm version --output=short)" = "v1.9.3" ]; then
+        local kubeV=$(kubeadm version --output=short)
+
+        if [ "$kubeV" = "v1.9.3" ]; then
             kubeadm init \
                 --skip-preflight-checks \
+                --kubernetes-version="$kubeV" \
                 --config /opt/replicated/kubeadm.conf \
                 | tee /tmp/kubeadm-init
             _status=$?
         else
             kubeadm init \
                 --ignore-preflight-errors=all \
+                --kubernetes-version="$kubeV" \
                 --config /opt/replicated/kubeadm.conf \
                 | tee /tmp/kubeadm-init
             _status=$?


### PR DESCRIPTION
Prevents the need for a GET https://dl.k8s.io/release/stable-1.11.txt

Also retry kubeadm upgrade node config in case K8s API is temporarily unavailable.