### PR TITLE
generate kubeadm-flags.env file

### DIFF
--- a/install_scripts/templates/kubernetes/init.sh
+++ b/install_scripts/templates/kubernetes/init.sh
@@ -101,14 +101,12 @@ initKube() {
         if [ "$kubeV" = "v1.9.3" ]; then
             kubeadm init \
                 --skip-preflight-checks \
-                --kubernetes-version="$kubeV" \
                 --config /opt/replicated/kubeadm.conf \
                 | tee /tmp/kubeadm-init
             _status=$?
         else
             kubeadm init \
                 --ignore-preflight-errors=all \
-                --kubernetes-version="$kubeV" \
                 --config /opt/replicated/kubeadm.conf \
                 | tee /tmp/kubeadm-init
             _status=$?


### PR DESCRIPTION
The kubeadm alpha phase kubelet write-env-file attempts to lookup the
stable version of k8s and does not have a --kubernetes-version flag to
disable like other commands.

Kubeadm init does not need --kubernetes-version flag - it's specified in
the config file.