### PR TITLE
Add helm chart for replicated

### DIFF
--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+appVersion: "2.22.0"
+description: A Helm chart for Kubernetes
+name: replicated
+version: 0.1.0
+maintainers:
+  - name: replicatedhq
+    email: replicatedhq@replicated.com

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "replicated.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "replicated.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "replicated.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/chart/templates/clusterrole/clusterrole.yaml
+++ b/chart/templates/clusterrole/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: replicated-admin
+  namespace: {{ .Values.clusterRole.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Values.clusterRole.namespace }}

--- a/chart/templates/deployment/replicated.yaml
+++ b/chart/templates/deployment/replicated.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "replicated.name" . }}
+  labels:
+    app: {{ template "replicated.name" . }}
+    tier: master
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "replicated.name" . }}
+      tier: master
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: replicated
+        tier: master
+    spec:
+      containers:
+      - name: replicated
+        image: "{{ .Values.deployment.replicated.repository }}:{{ .Values.deployment.replicated.tag }}"
+        imagePullPolicy: {{ .Values.deployment.replicated.pullPolicy }}
+        env:
+        - name: SCHEDULER_ENGINE
+          value: kubernetes
+        - name: RELEASE_CHANNEL
+          value: {{ .Values.deployment.env.releaseChannel }}
+        {{- if .Values.deployment.replicated.env.releaseSequence }}
+        - name: RELEASE_SEQUENCE
+          value: {{ .Values.deployment.replicated.env.releaseSequence }}
+        {{- end }}
+        {{- if .Values.deployment.replicated.env.customerBaseURLOverride }}
+        - name: MARKET_BASE_URL
+          value: .Values.deployment.replicated.env.customerBaseURLOverride
+        {{- end }}
+        - name: LOCAL_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: "status.podIP"
+        - name: K8S_MASTER_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_STORAGECLASS
+          value: "default"
+        - name: LOG_LEVEL
+          value: {{ .Values.deployment.env.logLevel }}
+        - name: AIRGAP
+          value: ""
+        {{- if .Values.deployment.replicated.env.proxyAddress }}
+        - name: HTTP_PROXY
+          value: {{ .Values.deployment.replicated.env.proxyAddress }}
+        - name: NO_PROXY
+          value: {{ .Values.deployment.replicated.env.noProxyAddress }}
+        {{- end }}
+        ports:
+        - containerPort: 9874
+        - containerPort: 9877
+        - containerPort: 9878
+        volumeMounts:
+        - name: replicated-persistent
+          mountPath: /var/lib/replicated
+        - name: replicated-socket
+          mountPath: /var/run/replicated
+        - name: docker-socket
+          mountPath: /host/var/run/docker.sock
+        - name: replicated-conf
+          mountPath: /host/etc/replicated.conf
+        - name: proc
+          mountPath: /host/proc
+          readOnly: true
+      - name: replicated-ui
+        image: "{{ .Values.deployment.ui.repository }}:{{ .Values.deployment.ui.tag }}"
+        imagePullPolicy: {{ .Values.deployment.ui.pullPolicy }}
+        env:
+        - name: RELEASE_CHANNEL
+          value: {{ .Values.deployment.env.releaseChannel }}
+        - name: LOG_LEVEL
+          value: {{ .Values.deployment.env.logLevel }}
+        ports:
+        - containerPort: 8800
+        volumeMounts:
+        - name: replicated-socket
+          mountPath: /var/run/replicated
+      volumes:
+      - name: replicated-persistent
+        persistentVolumeClaim:
+          claimName: replicated-pv-claim
+      - name: replicated-socket
+      - name: docker-socket
+        hostPath:
+          path: /var/run/docker.sock
+      - name: replicated-conf
+        hostPath:
+          path: /etc/replicated.conf
+      - name: proc
+        hostPath:
+          path: /proc

--- a/chart/templates/pvc/replicated-premkit-data-volume.yaml
+++ b/chart/templates/pvc/replicated-premkit-data-volume.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: replicated-premkit-data-volume
+  labels:
+    app: replicated
+    tier: premkit
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: {{ .Values.persistence.storageClass }}

--- a/chart/templates/pvc/replicated-pv-claim.yaml
+++ b/chart/templates/pvc/replicated-pv-claim.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: replicated-pv-claim
+  labels:
+    app: replicated
+    tier: master
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: "10Gi"
+  storageClassName: {{ .Values.persistence.storageClass }}

--- a/chart/templates/pvc/replicated-statsd-graphite-storage.yaml
+++ b/chart/templates/pvc/replicated-statsd-graphite-storage.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: replicated-statsd-graphite-storage
+  labels:
+    app: replicated
+    tier: statsd
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: {{ .Values.persistence.storageClass }}

--- a/chart/templates/service/replicated-ui.yaml
+++ b/chart/templates/service/replicated-ui.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: replicated-ui
+  labels:
+    app: replicated
+    tier: master
+spec:
+  type: {{ .Values.uiService.type }}
+  selector:
+    app: replicated
+    tier: master
+  ports:
+  - name: replicated-ui
+    port: 8800
+    nodePort: {{ .Values.uiService.port }}
+    protocol: TCP

--- a/chart/templates/service/replicated.yaml
+++ b/chart/templates/service/replicated.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: replicated
+  labels:
+    app: replicated
+    tier: master
+spec:
+  selector:
+    app: replicated
+    tier: master
+  ports:
+  - name: replicated-registry
+    port: 9874
+    protocol: TCP
+  - name: replicated-iapi
+    port: 9877
+    protocol: TCP
+  - name: replicated-snapshots
+    port: 9878
+    protocol: TCP
+  - name: replicated-support
+    port: 9881
+    protocol: TCP

--- a/chart/templates/storageclass/storageclass.yaml
+++ b/chart/templates/storageclass/storageclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: "default"
+provisioner: ceph.rook.io/block
+parameters:
+  pool: replicapool
+  clusterNamespace: rook-ceph

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,34 @@
+# config for replicated deployment
+deployment:
+  # config for replicated container
+  replicated:
+    repository: quay.io/replicated/replicated
+    tag: stable-2.22.0
+    pullPolicy: IfNotPresent
+    env:
+      releaseSequence: ""
+      proxyAddress: ""
+      noProxyAddress: ""
+      customerBaseURLOverride: ""
+  # config for replicated-ui container
+  ui:
+    repository: quay.io/replicated/replicated-ui
+    tag: stable-2.22.0
+    pullPolicy: IfNotPresent
+  # shared env configs with replicated and ui
+  env:
+    releaseChannel: "default"
+    logLevel: "info"
+
+# config for replicated-ui service
+uiService:
+  type: NodePort
+  port: 8800
+
+# storage class name used for pvcs
+persistence:
+  storageClass: "default"
+
+# config for clusterrole
+clusterRole:
+  namespace: "default"


### PR DESCRIPTION
What I Did
------------
- Translate yaml generated from `/kubernetes-yaml-generate` to a Helm chart that exposes the same values

How I Did it
------------
- Translated the following template variables (excluding those related to rook)

| kubernetes template argument | values.yaml                                               |
|------------------------------|-----------------------------------------------------------|
| channel_name                 | .Values.deployment.env.releaseChannel                     |
| replicated_tag               | .Values.deployment.replicated.env.releaseChannel          |
| pv_base_path                 |                                                           |
| log_level                    | .Values.deployment.env.logLevel                           |
| release_sequence             | .Values.deployment.replicated.env.releaseSequence         |
| storage_class                | .Values.persistence.storageClass                          |
| storage_provisioner          |                                                           |
| service_type                 | .Values.uiService.type                                    |
| kubernetes_namespace         | .Values.clusterRole.namespace                             |
| ui_bind_port                 | .Values.uiService.port                                    |
| proxy_address                | .Values.deployment.replicated.env.proxyAddress            |
| no_proxy_address             | .Values.deployment.replicated.env.noProxyAddress          |
| customer_base_url_override   | .Values.deployment.replicated.env.customerBaseURLOverride |

How to verify it
------------
- Run `ship init` pointed to the helm chart
