### PR TITLE
Fixes for replicated helm chart

### DIFF
--- a/chart/templates/deployment/replicated.yaml
+++ b/chart/templates/deployment/replicated.yaml
@@ -48,7 +48,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: K8S_STORAGECLASS
-          value: "default"
+          value: {{ .Values.persistence.storageClass }}
         - name: LOG_LEVEL
           value: {{ .Values.deployment.env.logLevel }}
         - name: AIRGAP

--- a/chart/templates/service/replicated-ui.yaml
+++ b/chart/templates/service/replicated-ui.yaml
@@ -7,11 +7,19 @@ metadata:
     tier: master
 spec:
   type: {{ .Values.uiService.type }}
+  {{- if and (eq .Values.uiService.type "LoadBalancer") .Values.uiService.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.uiService.loadBalancerIP }}
+  {{- end }}
   selector:
     app: replicated
     tier: master
   ports:
   - name: replicated-ui
     port: 8800
-    nodePort: {{ .Values.uiService.port }}
+    {{- if and (eq .Values.uiService.type "ClusterIP") .Values.uiService.targetPort }}
+    targetPort: {{ .Values.uiService.targetPort }}
+    {{- end }}
+    {{- if and (eq .Values.uiService.type "NodePort") .Values.uiService.nodePort }}
+    nodePort: {{ .Values.uiService.nodePort }}
+    {{- end }}
     protocol: TCP

--- a/chart/templates/storageclass/storageclass.yaml
+++ b/chart/templates/storageclass/storageclass.yaml
@@ -1,8 +1,0 @@
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-   name: "default"
-provisioner: ceph.rook.io/block
-parameters:
-  pool: replicapool
-  clusterNamespace: rook-ceph

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3,7 +3,7 @@ deployment:
   # config for replicated container
   replicated:
     repository: quay.io/replicated/replicated
-    tag: stable-2.25.2
+    tag: latest
     pullPolicy: IfNotPresent
     env:
       releaseSequence: ""
@@ -13,7 +13,7 @@ deployment:
   # config for replicated-ui container
   ui:
     repository: quay.io/replicated/replicated-ui
-    tag: stable-2.25.2
+    tag: latest
     pullPolicy: IfNotPresent
   # shared env configs with replicated and ui
   env:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3,21 +3,21 @@ deployment:
   # config for replicated container
   replicated:
     repository: quay.io/replicated/replicated
-    tag: stable-2.22.0
+    tag: stable-2.25.2
     pullPolicy: IfNotPresent
     env:
       releaseSequence: ""
       proxyAddress: ""
-      noProxyAddress: ""
+      noProxyAddress: "10.96.0.0/12"
       customerBaseURLOverride: ""
   # config for replicated-ui container
   ui:
     repository: quay.io/replicated/replicated-ui
-    tag: stable-2.22.0
+    tag: stable-2.25.2
     pullPolicy: IfNotPresent
   # shared env configs with replicated and ui
   env:
-    releaseChannel: "default"
+    releaseChannel: "stable"
     logLevel: "info"
 
 # config for replicated-ui service
@@ -27,7 +27,7 @@ uiService:
 
 # storage class name used for pvcs
 persistence:
-  storageClass: "default"
+  storageClass: "standard"
 
 # config for clusterrole
 clusterRole:


### PR DESCRIPTION
What I Did
------------
- Various fixes for replicated helm chart

How I Did it
------------
- Allow ui to be deployed as LoadBalancer, ClusterIP, or NodePort (default)
- Update replicated image to stable-2.25.2
- Update default noProxyAddress to CIDR 10.96.0.0/12
- Change releaseChannel from default to stable
- Change storageClass from default to standard
- Update K8S_STORAGECLASS env variable to use storageClass from values.yaml











<!-- (thanks https://github.com/docker/docker for this template) -->
