### PR TITLE
Fixes for AKA on RHEL7.4

### DIFF
--- a/install_scripts/templates/common/docker-install.sh
+++ b/install_scripts/templates/common/docker-install.sh
@@ -67,7 +67,6 @@ installDocker_1_12_Offline() {
         return
     fi
 
-    # TODO support more things or something
     case "$LSB_DIST$DIST_VERSION" in
         ubuntu16.04)
             mkdir -p image/
@@ -84,7 +83,7 @@ installDocker_1_12_Offline() {
             layer_id=$(tar xvf packages-docker-rhel7.tar -C image/ | grep layer.tar | cut -d'/' -f1)
             tar xvf image/${layer_id}/layer.tar
             pushd archives/
-                yum install -y -q *.rpm 
+                rpm --upgrade --force --nodeps *.rpm
             popd
             DID_INSTALL_DOCKER=1
             return

--- a/install_scripts/templates/common/kubernetes.sh
+++ b/install_scripts/templates/common/kubernetes.sh
@@ -553,11 +553,11 @@ spinnerMasterNodeReady()
 #######################################
 labelMasterNode()
 {
-    if kubectl get nodes --show-labels | grep "$DAEMON_NODE_KEY" > /dev/null ; then
+    if kubectl get nodes --show-labels | grep -q "$DAEMON_NODE_KEY" ; then
         return
     fi
 
-    kubectl label nodes "$(k8sMasterNodeName)" "$DAEMON_NODE_KEY"=
+    kubectl label nodes --overwrite "$(k8sMasterNodeName)" "$DAEMON_NODE_KEY"=
 }
 
 #######################################

--- a/install_scripts/templates/common/selinux.sh
+++ b/install_scripts/templates/common/selinux.sh
@@ -107,30 +107,4 @@ must_disable_selinux() {
             bail "\nDisable SELinux with 'setenforce 0' before re-running install script"
         fi
     fi
-
-    # https://github.com/containers/container-selinux/issues/51
-    # required for CoreDNS because it sets allowPrivilegeEscalation: false
-    if selinux_enabled ; then
-        mkdir -p policy
-        cd policy
-        # tabs required
-        cat <<-EOF > dockersvirt.te
-		module dockersvirt 1.0;
-
-		require {
-			type container_runtime_t;
-			type svirt_lxc_net_t;
-			role system_r;
-		};
-
-		typebounds container_runtime_t svirt_lxc_net_t;
-		EOF
-
-        checkmodule -M -m -o dockersvirt.mod dockersvirt.te
-        semodule_package -o dockersvirt.pp -m dockersvirt.mod
-        semodule -i dockersvirt.pp
-
-        cd ..
-        rm -r policy
-    fi
 }

--- a/install_scripts/templates/kubernetes/init.sh
+++ b/install_scripts/templates/kubernetes/init.sh
@@ -135,6 +135,10 @@ initKube() {
                 | tee /tmp/kubeadm-init
             _status=$?
         fi
+        # workaround for https://github.com/kubernetes/kubeadm/issues/998
+        kubectl -n kube-system get deployment coredns -o yaml | \
+            sed 's/allowPrivilegeEscalation: false/allowPrivilegeEscalation: true/g' | \
+            kubectl apply -f -
         set -e
         if [ "$_status" -ne "0" ]; then
             printf "${RED}Failed to initialize the kubernetes cluster.${NC}\n" 1>&2


### PR DESCRIPTION
Fix the kubernetes-init install script fails on the image "Red Hat
Enterprise Linux for SAP Applications 7.4" in Google cloud.
Use `rpm --upgrade --nodeps` for installing Docker packages, matching
how Kubernetes packages are installed on RHEL.
Remove allowPrivilegeEscalation from CoreDNS yaml; the previous fix of
writing a custom policy fails on this RHEL image.