### PR TITLE
fix ceph-dashboard-url missing in yaml opts

### DIFF
--- a/install_scripts/templates/kubernetes/init.sh
+++ b/install_scripts/templates/kubernetes/init.sh
@@ -299,8 +299,6 @@ rookDeploy() {
         return
     fi
 
-    CEPH_DASHBOARD_URL=http://rook-ceph-mgr-dashboard.rook-ceph.svc.cluster.local:7000
-
     # namespaces used in Rook 0.8+
     if k8sNamespaceExists rook-ceph && k8sNamespaceExists rook-ceph-system ; then
         logSuccess "Rook already deployed"
@@ -583,6 +581,10 @@ done
 
 if [ "$KUBERNETES_VERSION" == "1.9.3" ]; then
     IPVS=0
+fi
+
+if [ "$STORAGE_PROVISIONER" == "rook" ] || [ "$STORAGE_PROVISIONER" == "1" ]; then
+    CEPH_DASHBOARD_URL=http://rook-ceph-mgr-dashboard.rook-ceph.svc.cluster.local:7000
 fi
 
 if [ "$RESET" == "1" ]; then


### PR DESCRIPTION
The getYAMLOpts function runs before the rookDeploy function, so the
CEPH_DASHBOARD_URL was not getting passed to the yaml generator.