### PR TITLE
Set the NO_PROXY variable in Replicated container

### DIFF
--- a/install_scripts/templates/replicated-2.0.sh
+++ b/install_scripts/templates/replicated-2.0.sh
@@ -259,6 +259,10 @@ build_replicated_opts() {
         if [ -n "$PROXY_ADDRESS" ]; then
             REPLICATED_OPTS="$REPLICATED_OPTS -e HTTP_PROXY=$PROXY_ADDRESS"
         fi
+        REPLICATED_OPTS=$(echo "$REPLICATED_OPTS" | sed -e 's/-e[[:blank:]]*NO_PROXY=[^[:blank:]]*//')
+        if [ -n "$NO_PROXY_ADDRESSES" ]; then
+           REPLICATED_OPTS="$REPLICATED_OPTS -e NO_PROXY=$NO_PROXY_ADDRESSES"
+        fi
         REPLICATED_OPTS=$(echo "$REPLICATED_OPTS" | sed -e 's/-e[[:blank:]]*REGISTRY_ADVERTISE_ADDRESS=[^[:blank:]]*//')
         if [ -n "$REGISTRY_ADVERTISE_ADDRESS" ]; then
             REPLICATED_OPTS="$REPLICATED_OPTS -e REGISTRY_ADVERTISE_ADDRESS=$REGISTRY_ADVERTISE_ADDRESS"


### PR DESCRIPTION
Running install script first without the `http_proxy` parameter and then again with the parameter results in Replicated containers not having the NO_PROXY variable set.

[ch15399]