### PR TITLE
Replicated systemd service not restarting [ch14874]

### DIFF
--- a/install_scripts/templates/systemd/replicated-operator.service
+++ b/install_scripts/templates/systemd/replicated-operator.service
@@ -37,4 +37,4 @@ Restart=on-failure
 RestartSec=7
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=docker.service

--- a/install_scripts/templates/systemd/replicated-ui.service
+++ b/install_scripts/templates/systemd/replicated-ui.service
@@ -25,4 +25,4 @@ Restart=on-failure
 RestartSec=7
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=docker.service

--- a/install_scripts/templates/systemd/replicated.service
+++ b/install_scripts/templates/systemd/replicated.service
@@ -38,4 +38,4 @@ Restart=on-failure
 RestartSec=7
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=docker.service


### PR DESCRIPTION
When a service is updated systemd will do a stop and then start. Because of this the replicated services do not come back up after docker update. This change will cause replicated to start EVERY time docker unit starts. This changes functionality. For example if you stop replicated and then restart docker replicated will come back up. Prior to this change it would only come back up on reboot. In order to stop it for good you will have to disable the service. I think this should be ok since really the replicated service should always be running.