### PR TITLE
dpkg in aka install ignores version dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: apk add make
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS quay.io
       - run:
           name: build & push
@@ -55,7 +54,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: apk add make
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS quay.io
       - run:
           name: build & push
@@ -69,7 +67,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: apk add make
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS quay.io
       - run:
           name: build & push
@@ -83,7 +80,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: apk add make
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS quay.io
       - run:
           name: build & push
@@ -97,7 +93,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: apk add make
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS quay.io
       - run:
           name: build & push

--- a/install_scripts/templates/common/docker-install.sh
+++ b/install_scripts/templates/common/docker-install.sh
@@ -73,7 +73,7 @@ installDocker_1_12_Offline() {
             layer_id=$(tar xvf packages-docker-ubuntu1604.tar -C image/ | grep layer.tar | cut -d'/' -f1)
             tar xvf image/${layer_id}/layer.tar
             pushd archives/
-               dpkg -i *.deb
+               dpkg -i --force-depends-version *.deb
             popd
             DID_INSTALL_DOCKER=1
             return

--- a/install_scripts/templates/common/kubernetes-upgrade.sh
+++ b/install_scripts/templates/common/kubernetes-upgrade.sh
@@ -197,7 +197,7 @@ upgradeK8sMaster() {
     case "$LSB_DIST$DIST_VERSION" in
         ubuntu16.04)
             export DEBIAN_FRONTEND=noninteractive
-            dpkg -i archives/*.deb
+            dpkg -i --force-depends-version archives/*.deb
             ;;
         centos7.4|centos7.5|rhel7.4|rhel7.5)
             rpm --upgrade --force --nodeps archives/*.rpm
@@ -237,7 +237,7 @@ upgradeK8sNode() {
     case "$LSB_DIST$DIST_VERSION" in
         ubuntu16.04)
             export DEBIAN_FRONTEND=noninteractive
-            dpkg -i archives/*.deb
+            dpkg -i --force-depends-version archives/*.deb
             ;;
         centos7.4|centos7.5|rhel7.4|rhel7.5)
             rpm --upgrade --force --nodeps archives/*.rpm

--- a/install_scripts/templates/common/kubernetes.sh
+++ b/install_scripts/templates/common/kubernetes.sh
@@ -142,7 +142,7 @@ installKubernetesComponents() {
     case "$LSB_DIST$DIST_VERSION" in
         ubuntu16.04)
             export DEBIAN_FRONTEND=noninteractive
-            dpkg -i archives/*.deb
+            dpkg -i --force-depends-version archives/*.deb
             ;;
 
         centos7.4|centos7.5|rhel7.4|rhel7.5)


### PR DESCRIPTION
Prevent the install from failing after changes like https://launchpad.net/ubuntu/+source/kmod/22-1ubuntu5.1