### PR TITLE
update centos selinux image urls [ch16892]

### DIFF
--- a/install_scripts/templates/common/docker-install.sh
+++ b/install_scripts/templates/common/docker-install.sh
@@ -173,8 +173,8 @@ _installDocker() {
                 printf "{$GREEN}Installed container-selinux from existing sources{$NC}\n"
             else
                 # Install container-selinux from mirror.centos.org
-                yum install -y -q "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.42-1.gitad8f0f7.el7.noarch.rpm" || \
-                    yum install -y -q "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.33-1.git86f33cd.el7.noarch.rpm"
+                yum install -y -q "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm" || \
+                    yum install -y -q "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.74-1.el7.noarch.rpm"
                 if yum list installed "container-selinux" >/dev/null 2>&1; then
                     printf "${YELLOW}Installed package required by docker container-selinux from fallback source of mirror.centos.org${NC}\n"
                 else

--- a/install_scripts/templates/common/docker-install.sh
+++ b/install_scripts/templates/common/docker-install.sh
@@ -173,8 +173,8 @@ _installDocker() {
                 printf "{$GREEN}Installed container-selinux from existing sources{$NC}\n"
             else
                 # Install container-selinux from mirror.centos.org
-                yum install -y -q "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm" || \
-                    yum install -y -q "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.74-1.el7.noarch.rpm"
+                yum install -y -q "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.74-1.el7.noarch.rpm" || \
+                    yum install -y -q "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.68-1.el7.noarch.rpm"
                 if yum list installed "container-selinux" >/dev/null 2>&1; then
                     printf "${YELLOW}Installed package required by docker container-selinux from fallback source of mirror.centos.org${NC}\n"
                 else


### PR DESCRIPTION
https://app.clubhouse.io/replicated/story/16892/container-selinux-packages-we-are-referencing-are-no-longer-hosted-on-centos-mirror

container-selinux packages we are referencing are no longer hosted on centos mirror