### PR TITLE
always bind daemon to k8s master node

### DIFF
--- a/kustomize/overlays/dev/deployment.yaml
+++ b/kustomize/overlays/dev/deployment.yaml
@@ -10,9 +10,9 @@ spec:
         - name: install-scripts
           env:
             - name: ENVIRONMENT
-              value: dev
+              value: staging
             - name: REPLICATED_INSTALL_URL
-              value: http://localhost:8090
+              value: http://ebff0185.ngrok.io
             - name: GRAPHQL_PREM_ENDPOINT
               value: http://docker.for.mac.host.internal:8033/graphql
             - name: REGISTRY_ENDPOINT


### PR DESCRIPTION
Since we use the downward API to lookup the K8s API server address.