### PR TITLE
remove old certificates before replacing CA

### DIFF
--- a/install_scripts/templates/kubernetes/migrate.sh
+++ b/install_scripts/templates/kubernetes/migrate.sh
@@ -251,6 +251,7 @@ restoreSecrets() {
         return
     fi
     kubectl cp "${TMP_DIR}/secrets.tar" "$replPod":/tmp/secrets.tar -c replicated
+    kubectl exec "$replPod" -c replicated -- rm -rf /var/lib/replicated/secrets
     kubectl exec "$replPod" -c replicated -- tar -xf /tmp/secrets.tar -C /var/lib/replicated 
 }
 


### PR DESCRIPTION
The certificates generated with the replaced CA won't validate.