### PR TITLE
sleep after killing ui container

### DIFF
--- a/install_scripts/templates/kubernetes/migrate.sh
+++ b/install_scripts/templates/kubernetes/migrate.sh
@@ -289,7 +289,8 @@ startAppOnK8s() {
     # restart ui container to pick up new TLS certs from daemon
     local replPod=$(kubectl get pods --selector='app=replicated,tier=master' | tail -1 | awk '{ print $1 }')
     if [ -n "$replPod" ]; then
-        kubectl exec "$replPod" -c replicated-ui -- kill 1
+        kubectl exec "$replPod" -c replicated-ui -- kill 1 || true
+        sleep 30
     fi
 
     if [ "$needsActivation" = "1" ]; then

--- a/install_scripts/templates/kubernetes/migrate.sh
+++ b/install_scripts/templates/kubernetes/migrate.sh
@@ -289,6 +289,7 @@ startAppOnK8s() {
     # restart ui container to pick up new TLS certs from daemon
     local replPod=$(kubectl get pods --selector='app=replicated,tier=master' | tail -1 | awk '{ print $1 }')
     if [ -n "$replPod" ]; then
+        logSubstep "waiting for replicated-ui to restart"
         kubectl exec "$replPod" -c replicated-ui -- kill 1 || true
         sleep 30
     fi


### PR DESCRIPTION
QA revealed a couple different errors that may happen at or after
restarting the replicated-ui container. Ignoring the error of that
operation and sleeping afterward seems to prevent the issue.