### PR TITLE
use default rook dataDirHostPath

### DIFF
--- a/install_scripts/templates/kubernetes/migrate.sh
+++ b/install_scripts/templates/kubernetes/migrate.sh
@@ -108,7 +108,7 @@ purgeNativeScheduler() {
         retraced-cron \
         retraced-nsqd \
         retraced-postgres 2>/dev/null
-    rm -rf /var/lib/replicated* \
+    rm -rf /var/lib/replicated-operator \
         /etc/default/replicated* \
         /etc/sysconfig/replicated*
     set -e

--- a/install_scripts/templates/kubernetes/yml-generate.sh
+++ b/install_scripts/templates/kubernetes/yml-generate.sh
@@ -918,7 +918,7 @@ metadata:
   name: rook-ceph
   namespace: rook-ceph
 spec:
-  dataDirHostPath: /var/lib/replicated/rook
+  dataDirHostPath: /var/lib/rook
   # The service account under which to run the daemon pods in this cluster if the default account is not sufficient (OSDs)
   serviceAccount: rook-ceph-cluster
   # set the amount of mons to be started

--- a/kustomize/overlays/dev/deployment.yaml
+++ b/kustomize/overlays/dev/deployment.yaml
@@ -10,9 +10,9 @@ spec:
         - name: install-scripts
           env:
             - name: ENVIRONMENT
-              value: dev
+              value: staging
             - name: REPLICATED_INSTALL_URL
-              value: http://localhost:8090
+              value: http://2c39368d.ngrok.io
             - name: GRAPHQL_PREM_ENDPOINT
               value: http://docker.for.mac.host.internal:8033/graphql
             - name: REGISTRY_ENDPOINT

--- a/kustomize/overlays/dev/deployment.yaml
+++ b/kustomize/overlays/dev/deployment.yaml
@@ -10,9 +10,9 @@ spec:
         - name: install-scripts
           env:
             - name: ENVIRONMENT
-              value: staging
+              value: dev
             - name: REPLICATED_INSTALL_URL
-              value: http://2c39368d.ngrok.io
+              value: http://localhost:8090
             - name: GRAPHQL_PREM_ENDPOINT
               value: http://docker.for.mac.host.internal:8033/graphql
             - name: REGISTRY_ENDPOINT


### PR DESCRIPTION
Do not purge /var/lib/replicated after migration since it's the default
location for snapshots.
With Rook now using /var/lib/rook, customers can safely remove
/var/lib/replicated as a manual step if they wish.