### PR TITLE
airgap HA fixes

### DIFF
--- a/install_scripts/templates/common/kubernetes.sh
+++ b/install_scripts/templates/common/kubernetes.sh
@@ -1255,10 +1255,27 @@ exportKubeconfig() {
 # Arguments:
 #   registry host
 # Returns:
-#   None
+#   ADDED_INSECURE_REGISTRY
 #######################################
+ADDED_INSECURE_REGISTRY=0
 addInsecureRegistry() {
     if grep -q "insecure-registry $1" /etc/systemd/system/docker.service.d/replicated-registry.conf 2>/dev/null ; then
+        return
+    fi
+    if grep "insecure-registries" /etc/docker/daemon.json 2>/dev/null | grep -q "$1" ; then
+        return
+    fi
+
+    # prefer to configure using /etc/docker/daemon.json since that does not require a docker restart
+    # but don't attempt to edit json if that file already exists.
+    if [ ! -f "/etc/docker/daemon.json" ]; then
+        cat <<EOF >/etc/docker/daemon.json
+{
+    "insecure-registries": ["$1"]
+}
+EOF
+        kill -SIGHUP $(pidof dockerd) || true
+        ADDED_INSECURE_REGISTRY=1
         return
     fi
     mkdir -p /etc/systemd/system/docker.service.d
@@ -1270,6 +1287,9 @@ $execStart --insecure-registry $1
 EOF
     systemctl daemon-reload
     systemctl restart docker
+    spinnerNodesReady
+
+    ADDED_INSECURE_REGISTRY=1
 }
 
 #######################################

--- a/install_scripts/templates/common/kubernetes.sh
+++ b/install_scripts/templates/common/kubernetes.sh
@@ -1274,7 +1274,7 @@ addInsecureRegistry() {
     "insecure-registries": ["$1"]
 }
 EOF
-        kill -SIGHUP $(pidof dockerd) || true
+        systemctl kill -s HUP --kill-who=main docker.service
         ADDED_INSECURE_REGISTRY=1
         return
     fi

--- a/install_scripts/templates/kubernetes/init.sh
+++ b/install_scripts/templates/kubernetes/init.sh
@@ -462,8 +462,9 @@ registryDeploy() {
     addInsecureRegistry "$SERVICE_CIDR"
     # check if there are worker nodes that need to be configured for the insecure registry
     local workers=$(kubectl get nodes --selector='!node-role.kubernetes.io/master' -o jsonpath='{.items[*].metadata.name}')
-    # check the ADDED_INSECURE_REGISTRY flag to ensure this is only shown once
-    if [ "$ADDED_INSECURE_REGISTRY" = "1" ] && [ -n "$workers" ]; then
+    local numMasters=$(kubectl get nodes --selector='node-role.kubernetes.io/master' | sed '1d' | wc -l)
+    # check the ADDED_INSECURE_REGISTRY flag and the number of masters to ensure this is only shown once
+    if [ "$ADDED_INSECURE_REGISTRY" = "1" ] && [ -n "$workers" ] && [ "$numMasters" -eq "1" ]; then
         cat <<EOF
 Configure Docker on all worker nodes to use http when pulling from the in-cluster registry before proceeding.
 

--- a/install_scripts/templates/kubernetes/init.sh
+++ b/install_scripts/templates/kubernetes/init.sh
@@ -458,9 +458,26 @@ registryDeploy() {
     done
     REGISTRY_ADDRESS_OVERRIDE="$registryIP:5000"
     YAML_GENERATE_OPTS="$YAML_GENERATE_OPTS registry-address-override=$REGISTRY_ADDRESS_OVERRIDE"
-    addInsecureRegistry "$SERVICE_CIDR"
-    waitForRegistry
 
+    addInsecureRegistry "$SERVICE_CIDR"
+    # check if there are worker nodes that need to be configured for the insecure registry
+    local workers=$(kubectl get nodes --selector='!node-role.kubernetes.io/master' -o jsonpath='{.items[*].metadata.name}')
+    # check the ADDED_INSECURE_REGISTRY flag to ensure this is only shown once
+    if [ "$ADDED_INSECURE_REGISTRY" = "1" ] && [ -n "$workers" ]; then
+        cat <<EOF
+Configure Docker on all worker nodes to use http when pulling from the in-cluster registry before proceeding.
+
+Example /etc/docker/daemon.json:
+{
+    "insecure-registries" ["$SERVICE_CIDR"]
+}
+
+Continue after updating nodes: $workers
+EOF
+    prompt
+    fi
+
+    waitForRegistry
     logSuccess "Registry deployed"
 }
 

--- a/install_scripts/templates/kubernetes/yml-generate.sh
+++ b/install_scripts/templates/kubernetes/yml-generate.sh
@@ -1616,7 +1616,7 @@ metadata:
   labels:
     app: docker-registry
 type: Opaque
-data:
+stringData:
   haSharedSecret: $haSharedSecret
 ---
 apiVersion: apps/v1beta1

--- a/install_scripts/templates/kubernetes/yml-generate.sh
+++ b/install_scripts/templates/kubernetes/yml-generate.sh
@@ -342,6 +342,7 @@ spec:
   resources:
     requests:
       storage: "$size"
+  storageClassName: "$STORAGE_CLASS"
 EOF
 }
 
@@ -361,6 +362,7 @@ spec:
   resources:
     requests:
       storage: 1Gi
+  storageClassName: "$STORAGE_CLASS"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -375,6 +377,7 @@ spec:
   resources:
     requests:
       storage: 10Gi
+  storageClassName: "$STORAGE_CLASS"
 EOF
 }
 


### PR DESCRIPTION
If a customer upgrades an airgap cluster from before 2.34 there will be workers that don't have docker configured to pull insecurely from the new docker registry. We don't have a chance to run a command on the workers so we must prompt the user to manually configure those nodes.

The prompt looks like this and blocks until the user hits any key.
```
Configure Docker on all worker nodes to use http when pulling from the in-cluster registry before proceeding.

Example /etc/docker/daemon.json:
{
    "insecure-registries" ["10.96.0.0/12"]
}

Continue after updating nodes: areed-airgap-worker
```