### PR TITLE
restart kube-proxy

### DIFF
--- a/install_scripts/templates/kubernetes/init.sh
+++ b/install_scripts/templates/kubernetes/init.sh
@@ -302,6 +302,10 @@ initKube() {
     if [ "$LOAD_BALANCER_ADDRESS_CHANGED" = "1" ]; then
         runUpgradeScriptOnAllRemoteNodes
         export KUBECONFIG=/etc/kubernetes/admin.conf
+
+        logStep "Restarting kube-proxy"
+        kubectl -n kube-system get pods | grep kube-proxy | awk '{print $1}' | xargs kubectl -n kube-system delete pod
+        logSuccess "Kube-proxy restarted"
     fi
 }
 


### PR DESCRIPTION
This code was removed when we switched back to ipvs, but it's also
needed for load balancer address changes.