### PR TITLE
Fix docker tag registry

### DIFF
--- a/install_scripts/templates/common/kubernetes.sh
+++ b/install_scripts/templates/common/kubernetes.sh
@@ -377,7 +377,7 @@ airgapLoadKubernetesCommonImages1115() {
         docker tag 86ff1a48ce14 weaveworks/weave-kube:2.4.0
         docker tag 647ad6d59818 weaveworks/weave-npc:2.4.0
         docker tag bf0c403ea58d weaveworks/weaveexec:2.4.0
-        docker tag d5ef411ad932 docker.io/registry:2
+        docker tag 9c1f09fe9a86 docker.io/registry:2
         docker tag 6521ac58ca80 docker.io/envoyproxy/envoy-alpine:v1.6.0
         docker tag 6a9ec4bcb60e gcr.io/heptio-images/contour:v0.5.0
         docker tag b5c343f1a3a6 rook/ceph:v0.8.1
@@ -408,7 +408,7 @@ airgapLoadKubernetesCommonImages1135() {
         docker tag 1f394ae9e226 docker.io/weaveworks/weave-kube:2.5.1
         docker tag 789b7f496034 docker.io/weaveworks/weave-npc:2.5.1
         docker tag 4cccd7ef6421 docker.io/weaveworks/weaveexec:2.5.1
-        docker tag 9c1f09fe9a86 docker.io/library/registry:2
+        docker tag d5ef411ad932 docker.io/registry:2
         docker tag 1186b980992e docker.io/envoyproxy/envoy-alpine:v1.9.1
         docker tag 0a0aad7cff75 gcr.io/heptio-images/contour:v0.11.0
         docker tag b5c343f1a3a6 docker.io/rook/ceph:v0.8.1


### PR DESCRIPTION
The 1.13.5 common bundle is the only one that has the updated registry
id.