### PR TITLE
HA airgap app registry service

### DIFF
--- a/bundles/k8s-containers/mk-image-cache-lst-v1.13.5
+++ b/bundles/k8s-containers/mk-image-cache-lst-v1.13.5
@@ -22,7 +22,8 @@ weave_version=2.5.1
 registry_version=2.6.2
 envoy_version=v1.9.1
 contour_version=v0.11.0
-rook_version=v0.8.1
+rook_version=v1.0.0
+ceph_version=v14.2.0-20190410
 replicated_hostpath_provisioner_version=cd1d272
 
 common="
@@ -36,6 +37,7 @@ common="
 	docker.io/envoyproxy/envoy-alpine:$envoy_version
 	gcr.io/heptio-images/contour:$contour_version
 	rook/ceph:$rook_version
+    ceph/ceph:$ceph_version
 	quay.io/replicated/replicated-hostpath-provisioner:$replicated_hostpath_provisioner_version"
 
 control="

--- a/install_scripts/templates/common/kubernetes.sh
+++ b/install_scripts/templates/common/kubernetes.sh
@@ -398,7 +398,7 @@ airgapLoadKubernetesCommonImages1123() {
 airgapLoadKubernetesCommonImages1135() {
     docker run \
         -v /var/run/docker.sock:/var/run/docker.sock \
-        "quay.io/replicated/k8s-images-common:v1.13.5-20190411"
+        "quay.io/replicated/k8s-images-common:v1.13.5-20190507"
 
     (
         set -x
@@ -411,7 +411,8 @@ airgapLoadKubernetesCommonImages1135() {
         docker tag d5ef411ad932 docker.io/registry:2
         docker tag 1186b980992e docker.io/envoyproxy/envoy-alpine:v1.9.1
         docker tag 0a0aad7cff75 gcr.io/heptio-images/contour:v0.11.0
-        docker tag b5c343f1a3a6 docker.io/rook/ceph:v0.8.1
+        docker tag eb6fe47e91ae docker.io/rook/ceph:v1.0.0
+        docker tag 243030ce8ef0 docker.io/ceph/ceph:v14.2.0-20190410
         docker tag 376cb7e8748c quay.io/replicated/replicated-hostpath-provisioner:cd1d272
     )
 }

--- a/install_scripts/templates/kubernetes/yml-generate.sh
+++ b/install_scripts/templates/kubernetes/yml-generate.sh
@@ -37,6 +37,7 @@ CONTOUR_YAML=0
 DEPLOYMENT_YAML=0
 REGISTRY_YAML=0
 REK_OPERATOR_YAML=0
+REPLICATED_REGISTRY_YAML=0
 BIND_DAEMON_NODE=0
 API_SERVICE_ADDRESS="{{ api_service_address }}"
 HA_CLUSTER="{{ ha_cluster }}"
@@ -137,6 +138,10 @@ while [ "$1" != "" ]; do
             ;;
         deployment-yaml|deployment_yaml)
             DEPLOYMENT_YAML="$_value"
+            REPLICATED_YAML=0
+            ;;
+        replicated-registry-yaml|replicated_registry_yaml)
+            REPLICATED_REGISTRY_YAML="$_value"
             REPLICATED_YAML=0
             ;;
         ip-alloc-range|ip_alloc_range)
@@ -1115,6 +1120,10 @@ fi
 
 if [ "$REK_OPERATOR_YAML" = "1" ]; then
     render_rek_operator_yaml
+fi
+
+if [ "$REPLICATED_REGISTRY_YAML" ]; then
+    render_replicated_registry_service
 fi
 
 if [ "$REPLICATED_YAML" = "1" ]; then

--- a/install_scripts/templates/kubernetes/yml-generate.sh
+++ b/install_scripts/templates/kubernetes/yml-generate.sh
@@ -52,7 +52,6 @@ while [ "$1" != "" ]; do
     case $_param in
         airgap)
             AIRGAP=1
-            BIND_DAEMON_NODE=1
             ;;
         bind-daemon-node|bind_daemon_node)
             BIND_DAEMON_NODE=1
@@ -254,6 +253,8 @@ spec:
         app: replicated
         tier: master
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
 $AFFINITY
       containers:
       - name: replicated
@@ -478,14 +479,13 @@ metadata:
     app: replicated
     tier: master
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: replicated
     tier: master
   ports:
   - name: replicated-registry
     port: 9874
-    nodePort: 9874
     protocol: TCP
 EOF
 }
@@ -1122,7 +1122,7 @@ if [ "$REK_OPERATOR_YAML" = "1" ]; then
     render_rek_operator_yaml
 fi
 
-if [ "$REPLICATED_REGISTRY_YAML" ]; then
+if [ "$REPLICATED_REGISTRY_YAML" = "1" ]; then
     render_replicated_registry_service
 fi
 
@@ -1134,9 +1134,6 @@ if [ "$REPLICATED_YAML" = "1" ]; then
     render_cluster_role_binding
     render_replicated_deployment
     render_replicated_service
-    if [ "$AIRGAP" = "1" ]; then
-        render_replicated_registry_service
-    fi
 
     if [ "$HA_CLUSTER" = "1" ]; then
         render_replicated_api_service


### PR DESCRIPTION
Use a ClusterIP service so HA airgap can tolerate the loss of any node.
Pre-render the registry service so the Cluster IP can be passed to the Replicated Deployment yaml.
Print the ClusterIP at the end with message about cert SANs.

Also update airgap common images for Rook 1.0 / Ceph v14, which are now separate images.