### PR TITLE
disable object store for registry

### DIFF
--- a/install_scripts/templates/kubernetes/init.sh
+++ b/install_scripts/templates/kubernetes/init.sh
@@ -678,7 +678,9 @@ objectStoreDeploy() {
 registryDeploy() {
     logStep "Deploy registry"
 
-    if isRook1; then
+    # https://github.com/rook/rook/issues/3245
+    # disabling object store backed registry until the object store is reliable
+    if isRook1 && false; then
         # cleanup pvc-backed registry if it exists; all images are re-pushed after this step
         if kubectl get pvc registry-data-docker-registry-0 &>/dev/null; then
             kubectl delete statefulset docker-registry

--- a/install_scripts/templates/kubernetes/node-join.sh
+++ b/install_scripts/templates/kubernetes/node-join.sh
@@ -430,6 +430,11 @@ fi
 
 if [ "$MASTER" -eq "1" ]; then
     untaintMaster
+    if [ "$AIRGAP" = "1" ]; then
+        # delete the rek operator so that its anti-affinity with the docker-registry applies
+        kubectl scale deployment rek-operator --replicas=0
+        kubectl scale deployment rek-operator --replicas=1
+    fi
 fi
 
 purgeNative

--- a/install_scripts/templates/kubernetes/yaml/rook-1-0-system.yml
+++ b/install_scripts/templates/kubernetes/yaml/rook-1-0-system.yml
@@ -455,6 +455,9 @@ spec:
         # For more details see https://github.com/rook/rook/issues/2254
         - name: ROOK_ENABLE_FSGROUP
           value: "true"
+        # Disable automatic orchestration when new devices are discovered
+        - name: ROOK_DISABLE_DEVICE_HOTPLUG
+          value: "true"
         # The name of the node to pass with the downward API
         - name: NODE_NAME
           valueFrom:

--- a/install_scripts/templates/kubernetes/yml-generate.sh
+++ b/install_scripts/templates/kubernetes/yml-generate.sh
@@ -936,6 +936,16 @@ spec:
       labels:
         app: rek-operator
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - docker-registry
+            topologyKey: "kubernetes.io/hostname"
       containers:
       - name: rek
         image: "${REGISTRY_ADDRESS_OVERRIDE:-$REPLICATED_DOCKER_HOST}/replicated/replicated:{{ replicated_tag }}{{ environment_tag_suffix }}"


### PR DESCRIPTION
The Rook operator has a bug that takes down the Ceph object store. Scheduling the REK operator on a separate node than the registry will at least avoid the case where the operator cannot be rescheduled after a node failure because its image cannot be pulled from the registry.