### PR TITLE
fix kubelet target version

### DIFF
--- a/install_scripts/templates/common/kubernetes-upgrade.sh
+++ b/install_scripts/templates/common/kubernetes-upgrade.sh
@@ -349,8 +349,7 @@ maybeUpgradeKubernetesNode() {
                 done
             else
                 local n=0
-                local ver=$(kubelet --version | cut -d ' ' -f 2)
-                while ! kubeadm upgrade node config --kubelet-version "$ver" ; do
+                while ! kubeadm upgrade node config --kubelet-version "$KUBERNETES_VERSION" ; do
                     n="$(( $n + 1 ))"
                     if [ "$n" -ge "10" ]; then
                         exit 1


### PR DESCRIPTION
We now defer upgrading host kubelet package until after node config has
been downloaded so we can't use kubelet to get the version we're
upgrading to.