### PR TITLE
wait for k8s api after kubelet restart

### DIFF
--- a/install_scripts/templates/common/kubernetes-upgrade.sh
+++ b/install_scripts/templates/common/kubernetes-upgrade.sh
@@ -685,6 +685,7 @@ upgradeK8sMaster() {
 
     systemctl daemon-reload
     systemctl start kubelet
+    spinnerK8sAPIHealthy
     kubectl uncordon "$node"
 
     sed -i "s/kubernetesVersion:.*/kubernetesVersion: v$k8sVersion/" /opt/replicated/kubeadm.conf


### PR DESCRIPTION
The kubelet needs to bring up the static kube-apiserver pod before
kubectl can be reliably used.