### PR TITLE
liveness probe success threshold must be 1

### DIFF
--- a/kustomize/base/deployment.yaml
+++ b/kustomize/base/deployment.yaml
@@ -37,7 +37,7 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 5
             periodSeconds: 2
-            successThreshold: 2
+            successThreshold: 1
             timeoutSeconds: 1
           # the readiness probe checks if the container can connect to the database
           readinessProbe:


### PR DESCRIPTION
apparently `1` is the only legal value for liveness probe success thresholds: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes