### PR TITLE
AKA clean shutdown

### DIFF
--- a/install_scripts/templates/common/kubernetes.sh
+++ b/install_scripts/templates/common/kubernetes.sh
@@ -1772,9 +1772,7 @@ KUBECONFIG=/etc/kubernetes/kubelet.conf kubectl cordon \$(hostname)
 
 # delete local pods with PVCs
 while read -r uid; do
-        echo "FOUND POD WITH PVC HAVING UID \$uid"
         podName=\$(KUBECONFIG=/etc/kubernetes/kubelet.conf kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\\t"}{.metadata.uid}{"\\n"}{end}' | grep \$uid | awk '{ print \$1 }')
-        echo "FOUND POD WITH NAME \$podName"
         KUBECONFIG=/etc/kubernetes/kubelet.conf kubectl delete pod \$podName --wait=false
 done < <(lsblk | grep '^rbd[0-9]' | awk '{ print \$7 }' | awk -F '/' '{ print \$6 }')
 

--- a/install_scripts/templates/common/kubernetes.sh
+++ b/install_scripts/templates/common/kubernetes.sh
@@ -1798,7 +1798,7 @@ done
 
 EOF
 
-chmod a+x /opt/replicated/shutdown.sh
+chmod u+x /opt/replicated/shutdown.sh
 }
 
 writeAKAExecStart()
@@ -1815,7 +1815,7 @@ done
 KUBECONFIG=/etc/kubernetes/kubelet.conf kubectl uncordon \$(hostname)
 EOF
 
-chmod a+x /opt/replicated/start.sh
+chmod u+x /opt/replicated/start.sh
 }
 
 writeAKAService()

--- a/install_scripts/templates/common/kubernetes.sh
+++ b/install_scripts/templates/common/kubernetes.sh
@@ -1763,6 +1763,16 @@ checkDockerK8sVersion()
     esac
 }
 
+installAKAService()
+{
+    writeAKAExecStop
+    writeAKAExecStart
+    writeAKAService
+
+    systemctl enable aka.service
+    systemctl start aka.service
+}
+
 writeAKAExecStop()
 {
 echo >/opt/replicated/shutdown.sh <<EOF
@@ -1799,7 +1809,7 @@ replicatedctl app start
 EOF
 }
 
-writeAKASerivce()
+writeAKAService()
 {
 cat >/etc/systemd/system/aka.service <<EOF
 [Unit]

--- a/install_scripts/templates/kubernetes/init.sh
+++ b/install_scripts/templates/kubernetes/init.sh
@@ -1300,6 +1300,8 @@ esac
 
 contourDeploy "$DISABLE_CONTOUR"
 
+installAKAService
+
 if [ "$KUBERNETES_ONLY" -eq "1" ]; then
     spinnerKubeSystemReady "$KUBERNETES_VERSION"
     rekOperatorDeploy

--- a/install_scripts/templates/kubernetes/node-join.sh
+++ b/install_scripts/templates/kubernetes/node-join.sh
@@ -457,6 +457,8 @@ if [ "$MASTER" -eq "1" ]; then
 
     installAliasFile
     logSuccess "Installed replicated command alias"
+
+    installAKAService
 fi
 
 waitForRook

--- a/install_scripts/templates/kubernetes/node-join.sh
+++ b/install_scripts/templates/kubernetes/node-join.sh
@@ -457,9 +457,9 @@ if [ "$MASTER" -eq "1" ]; then
 
     installAliasFile
     logSuccess "Installed replicated command alias"
-
-    installAKAService
 fi
+
+installAKAService
 
 waitForRook
 

--- a/install_scripts/templates/kubernetes/node-upgrade.sh
+++ b/install_scripts/templates/kubernetes/node-upgrade.sh
@@ -86,4 +86,6 @@ if [ "$AIRGAP" = "1" ]; then
     addInsecureRegistry "$SERVICE_CIDR"
 fi
 
+installAKAService
+
 maybeUpgradeKubernetesNode "$KUBERNETES_VERSION"

--- a/kustomize/overlays/dev/deployment.yaml
+++ b/kustomize/overlays/dev/deployment.yaml
@@ -8,6 +8,7 @@ spec:
     spec:
       containers:
         - name: install-scripts
+          image: replicated-install-scripts
           env:
             - name: ENVIRONMENT
               value: dev


### PR DESCRIPTION
aka.service with an ExecStop script to remove all pods with PVCs attached. Then poll until `lsblk` reports there are no more `rbd` devices on the node.

Still need to add support for non-masters, possibly by calling the flexvolume plugin directly on the host before the rook agent container goes down.