### PR TITLE
go get github.com/linuxkit/linuxkit/src/cmd/linuxkit requires go 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
 
   build_k8s_bundles:
     docker:
-    - image: cimg/go:1.13
+    - image: cimg/go:1.16
     working_directory: ~/repo
     <<: *environment
     steps:


### PR DESCRIPTION
Fixes build

```
go get github.com/linuxkit/linuxkit/src/cmd/linuxkit
package embed: unrecognized import path "embed" (import path does not begin with hostname)
Makefile:6: recipe for target 'deps' failed
make: *** [deps] Error 1

Exited with code exit status 2
```