### PR TITLE
Don't allow shell argument expansion when generating YAML files

### DIFF
--- a/install_scripts/app.py
+++ b/install_scripts/app.py
@@ -272,7 +272,6 @@ def get_replicated_compose_v3(replicated_channel=None,
                               app_channel=None):
     kwargs = get_replicated_compose_v3_template_args(replicated_channel,
                                                      app_slug, app_channel)
-    kwargs = {k: quote(v) for k, v in kwargs.items()}
 
     script = render_template(
         'swarm/docker-compose-generate.sh', suppress_runtime=1, **kwargs)
@@ -336,7 +335,6 @@ def get_replicated_kubernetes_yml(replicated_channel=None,
                                   app_channel=None):
     kwargs = get_kubernetes_yaml_template_args(replicated_channel, app_slug,
                                                app_channel)
-    kwargs = {k: quote(v) for k, v in kwargs.items()}
 
     script = render_template(
         'kubernetes/yml-generate.sh', suppress_runtime=1, **kwargs)
@@ -363,7 +361,6 @@ def get_kubernetes_operator_yml(replicated_channel=None,
                                 app_channel=None):
     kwargs = get_kubernetes_yaml_template_args(replicated_channel, app_slug,
                                                app_channel)
-    kwargs = {k: quote(v) for k, v in kwargs.items()}
 
     script = render_template(
         'kubernetes/yml-generate.sh', suppress_runtime=1, **kwargs)

--- a/install_scripts/app.py
+++ b/install_scripts/app.py
@@ -272,12 +272,13 @@ def get_replicated_compose_v3(replicated_channel=None,
                               app_channel=None):
     kwargs = get_replicated_compose_v3_template_args(replicated_channel,
                                                      app_slug, app_channel)
+    kwargs = {k: quote(v) for k, v in kwargs.items()}
 
     script = render_template(
         'swarm/docker-compose-generate.sh', suppress_runtime=1, **kwargs)
     p = subprocess.Popen(
         ['bash', '-'],
-        shell=True,
+        shell=False,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE)
     p.stdin.write(script)
@@ -335,11 +336,13 @@ def get_replicated_kubernetes_yml(replicated_channel=None,
                                   app_channel=None):
     kwargs = get_kubernetes_yaml_template_args(replicated_channel, app_slug,
                                                app_channel)
+    kwargs = {k: quote(v) for k, v in kwargs.items()}
+
     script = render_template(
         'kubernetes/yml-generate.sh', suppress_runtime=1, **kwargs)
     p = subprocess.Popen(
         ['bash -s deployment-yaml=1', '-'],
-        shell=True,
+        shell=False,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE)
     p.stdin.write(script)
@@ -360,11 +363,13 @@ def get_kubernetes_operator_yml(replicated_channel=None,
                                 app_channel=None):
     kwargs = get_kubernetes_yaml_template_args(replicated_channel, app_slug,
                                                app_channel)
+    kwargs = {k: quote(v) for k, v in kwargs.items()}
+
     script = render_template(
         'kubernetes/yml-generate.sh', suppress_runtime=1, **kwargs)
     p = subprocess.Popen(
         ['bash -s rek-operator-yaml=1', '-'],
-        shell=True,
+        shell=False,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE)
     p.stdin.write(script)

--- a/install_scripts/helpers.py
+++ b/install_scripts/helpers.py
@@ -74,7 +74,7 @@ def template_args(**kwargs):
 
 
 def get_arg(name, dflt=None):
-    return request.args.get(name) if request.args.get(name) else dflt
+    return make_shell_safe(request.args.get(name)) if request.args.get(name) else dflt
 
 
 def get_pinned_docker_version(replicated_version, scheduler):
@@ -524,3 +524,8 @@ def snapshots_use_overlay(replicated_version):
     if semver.lt(replicated_version, '2.22.0', loose=False):
         return False
     return True
+
+def make_shell_safe(s):
+    if type(s) == str or type(s) == unicode:
+        return s.replace('$', '_').replace('`', '\'')
+    return s


### PR DESCRIPTION
```
$ curl 'https://install-scripts-divolgin.replicated.okteto.dev/docker-compose.yml?log_level=$(pwd)'
....
      - LOG_LEVEL=_(pwd)
```

```
divolgin@repldev-dmitriy:~$ curl 'https://install-scripts-divolgin.replicated.okteto.dev/docker-compose.yml?log_level=`pwd`'
...
      - LOG_LEVEL='pwd'
```