### PR TITLE
Ensure replicated-ui becomes readonly on upgrades

### DIFF
--- a/install_scripts/templates/replicated-2.0.sh
+++ b/install_scripts/templates/replicated-2.0.sh
@@ -302,6 +302,8 @@ build_replicated_opts() {
                     REPLICATED_UI_OPTS="$REPLICATED_UI_OPTS $REPLICATED_DOCKER_READONLY_FLAG"
                 fi
             fi
+        else
+            REPLICATED_UI_OPTS=" $REPLICATED_DOCKER_READONLY_FLAG"
         fi
         return
     fi


### PR DESCRIPTION
Even if no other replicated-ui arguments are present, it should become readonly upon upgrade