### PR TITLE
Add uwsgi die-on-term=true

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -29,3 +29,4 @@ chdir = %d
 module=main:app
 # allow anyone to connect to the socket. This is very permissive
 chmod-socket=666
+die-on-term = true


### PR DESCRIPTION
uWSGI prior to 2.1 does not die on SIGTERM. I believe this is causing the delay between the SIGTERM request coming from k8s and the actual shutdown of the pods.