### PR TITLE
fix(installer): remove centos 7 and 8 repo due to eol

### DIFF
--- a/install_scripts/templates/common/docker-install.sh
+++ b/install_scripts/templates/common/docker-install.sh
@@ -228,13 +228,6 @@ _installDocker() {
             logSuccess "Installed yum-utils"
         fi
         getUrlCmd
-        if [ "$DIST_VERSION_MAJOR" -eq 7 ]; then
-            yum-config-manager --add-repo=http://mirror.centos.org/centos/7/extras/x86_64 || true
-            $URLGET_CMD "https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7" > EXTRAS_KEY
-        else
-            yum-config-manager --add-repo=http://mirror.centos.org/centos/8/extras/x86_64/os || true
-            $URLGET_CMD "https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official" > EXTRAS_KEY
-        fi
         rpm --import EXTRAS_KEY
         rm EXTRAS_KEY
     fi

--- a/install_scripts/templates/common/docker-install.sh
+++ b/install_scripts/templates/common/docker-install.sh
@@ -227,9 +227,6 @@ _installDocker() {
             yum install -y yum-utils
             logSuccess "Installed yum-utils"
         fi
-        getUrlCmd
-        rpm --import EXTRAS_KEY
-        rm EXTRAS_KEY
     fi
 
     _docker_install_url="{{ replicated_install_url }}/docker-install.sh"

--- a/install_scripts/templates/common/docker-install.sh
+++ b/install_scripts/templates/common/docker-install.sh
@@ -217,18 +217,6 @@ _installDocker() {
         fi
     fi
 
-    # docker-ce 20.10+ includes docker-ce-rootless-extras, which has some depenendencies not
-    # Found in any of the yum repos available on RHEL on Azure.
-    # Also seen on Oracle Enterprise Linux.
-    compareDockerVersions "20.10.0" "${1}"
-    if { [ "$LSB_DIST" = "rhel" ] || [ "$LSB_DIST" = "ol" ] ; } && [ "$COMPARE_DOCKER_VERSIONS_RESULT" -le "0" ]; then
-        if ! yum list installed "yum-utils" >/dev/null 2>&1; then
-            logStep "Installing yum-utils"
-            yum install -y yum-utils
-            logSuccess "Installed yum-utils"
-        fi
-    fi
-
     _docker_install_url="{{ replicated_install_url }}/docker-install.sh"
     printf "${GREEN}Installing docker version ${1} from ${_docker_install_url}${NC}\n"
     getUrlCmd


### PR DESCRIPTION
According to [EOL notice](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/)

- CentOS 8: May 31, 2024 
- CentOS 7: June 30, 2024

As a result, both http://mirror.centos.org/centos/7/extras/x86_64 and http://mirror.centos.org/centos/8/extras/x86_64/os are return 404 based on the EOL date.

Remove them for  failing at the docker install step