### PR TITLE
Update Nginx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,19 +150,18 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - setup_remote_docker:
-          version: "20.10.23"
+      - setup_remote_docker
       - run: |
           export WORKDIR=`pwd`
           export CIRCLE_PROJECT_REPONAME=$PROJECT_NAME
           build-docker
-      - deploy:
-          name: push image
-          command: |
-            export AWS_ACCESS_KEY_ID=$STAGING_AWS_ACCESS_KEY_ID
-            export AWS_SECRET_ACCESS_KEY=$STAGING_AWS_SECRET_ACCESS_KEY
-            export CIRCLE_PROJECT_REPONAME=$PROJECT_NAME
-            push-docker
+      # - deploy:
+      #     name: push image
+      #     command: |
+      #       export AWS_ACCESS_KEY_ID=$STAGING_AWS_ACCESS_KEY_ID
+      #       export AWS_SECRET_ACCESS_KEY=$STAGING_AWS_SECRET_ACCESS_KEY
+      #       export CIRCLE_PROJECT_REPONAME=$PROJECT_NAME
+      #       push-docker
 
   build_production_docker_image:
     <<: *defaults
@@ -171,8 +170,7 @@ jobs:
       ECR_REPO: 799720048698.dkr.ecr.us-east-1.amazonaws.com
     steps:
       - checkout
-      - setup_remote_docker:
-          version: "20.10.23"
+      - setup_remote_docker
       - run: |
           export WORKDIR=`pwd`
           export CIRCLE_PROJECT_REPONAME=$PROJECT_NAME
@@ -234,6 +232,10 @@ workflows:
             branches:
               ignore: main
       - test_python:
+          filters:
+            branches:
+              ignore: main
+      - build_staging_docker_image:
           filters:
             branches:
               ignore: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,13 +155,13 @@ jobs:
           export WORKDIR=`pwd`
           export CIRCLE_PROJECT_REPONAME=$PROJECT_NAME
           build-docker
-      # - deploy:
-      #     name: push image
-      #     command: |
-      #       export AWS_ACCESS_KEY_ID=$STAGING_AWS_ACCESS_KEY_ID
-      #       export AWS_SECRET_ACCESS_KEY=$STAGING_AWS_SECRET_ACCESS_KEY
-      #       export CIRCLE_PROJECT_REPONAME=$PROJECT_NAME
-      #       push-docker
+      - deploy:
+          name: push image
+          command: |
+            export AWS_ACCESS_KEY_ID=$STAGING_AWS_ACCESS_KEY_ID
+            export AWS_SECRET_ACCESS_KEY=$STAGING_AWS_SECRET_ACCESS_KEY
+            export CIRCLE_PROJECT_REPONAME=$PROJECT_NAME
+            push-docker
 
   build_production_docker_image:
     <<: *defaults
@@ -232,10 +232,6 @@ workflows:
             branches:
               ignore: main
       - test_python:
-          filters:
-            branches:
-              ignore: main
-      - build_staging_docker_image:
           filters:
             branches:
               ignore: main

--- a/deploy/Dockerfile.prod
+++ b/deploy/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder
+FROM golang:1.20 AS builder
 WORKDIR /docker-compose-generate
 COPY ./util/docker-compose-generate /docker-compose-generate
 RUN make build
@@ -9,28 +9,51 @@ COPY --from=builder /docker-compose-generate/dcg /dcg
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         git \
-        nginx \
+        build-essential \
+        libpcre3 \
+        libpcre3-dev \
+        zlib1g \
+        zlib1g-dev \
+        libssl-dev \
         supervisor \
     && rm -rf /var/lib/apt/lists/*
 
+WORKDIR /tmp
+RUN curl -O http://nginx.org/download/nginx-1.24.0.tar.gz \
+    && tar -zxvf nginx-1.24.0.tar.gz \
+    && cd nginx-1.24.0 \
+    && ./configure \
+        --with-http_ssl_module \
+        --with-http_v2_module \
+        --with-http_gzip_static_module \
+    && make \
+    && make install \
+    && rm -rf /tmp/nginx-1.24.0*
+
+# Add Nginx binary location to PATH
+ENV PATH="/usr/local/nginx/sbin:$PATH"
+
+# Set up Nginx and Supervisor configurations
+RUN echo "daemon off;" >> /usr/local/nginx/conf/nginx.conf
+RUN rm /usr/local/nginx/conf/nginx.conf
+ADD ./nginx-app.conf /usr/local/nginx/conf/
+ADD ./supervisor-app.conf /etc/supervisor/conf.d/
+
+# Copy Python app files
 ADD ./requirements.txt /home/docker/code/
 RUN pip install -r /home/docker/code/requirements.txt
 
-RUN echo "daemon off;" >> /etc/nginx/nginx.conf
-RUN rm /etc/nginx/sites-enabled/default
-ADD ./nginx-app.conf /etc/nginx/sites-enabled/
-ADD ./supervisor-app.conf /etc/supervisor/conf.d/
-
 ADD ./uwsgi_params /home/docker/code/
 ADD ./uwsgi.ini /home/docker/code/
-
 ADD ./install_scripts /home/docker/code/install_scripts/
 ADD ./main.py /home/docker/code/
 ADD Manifest /home/docker/code/
 ADD LICENSE /home/docker/code/
 
+# Generate Docker compose template
 RUN /dcg --raw > /home/docker/code/install_scripts/templates/swarm/docker-compose-generate-safe.sh
 
+# Expose Nginx port
 EXPOSE 80
 
 CMD ["supervisord", "-c", "/etc/supervisor/supervisord.conf", "-n"]

--- a/deploy/Dockerfile.prod
+++ b/deploy/Dockerfile.prod
@@ -34,9 +34,8 @@ RUN curl -O http://nginx.org/download/nginx-1.24.0.tar.gz \
 ENV PATH="/usr/local/nginx/sbin:$PATH"
 
 # Set up Nginx and Supervisor configurations
-RUN echo "daemon off;" >> /usr/local/nginx/conf/nginx.conf
 RUN rm /usr/local/nginx/conf/nginx.conf
-ADD ./nginx-app.conf /usr/local/nginx/conf/
+ADD ./nginx-app.conf /usr/local/nginx/conf/nginx.conf
 ADD ./supervisor-app.conf /etc/supervisor/conf.d/
 
 # Copy Python app files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,11 @@ services:
   install-scripts:
     build: .
     container_name: "replicated.install-scripts"
-    networks:
-      - default
-      - saas_default
-    external_links:
-      - replicated.saas.mysql:mysql
+    # networks:
+    #   - default
+    #   - saas_default
+    # external_links:
+    #   - replicated.saas.mysql:mysql
     ports:
       - "8090:5000"
     restart: always
@@ -24,6 +24,6 @@ services:
       - .:/usr/src/app
     command: [python, main.py]
 
-networks:
-  saas_default:
-    external: true
+# networks:
+#   saas_default:
+#     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,11 @@ services:
   install-scripts:
     build: .
     container_name: "replicated.install-scripts"
-    # networks:
-    #   - default
-    #   - saas_default
-    # external_links:
-    #   - replicated.saas.mysql:mysql
+    networks:
+      - default
+      - saas_default
+    external_links:
+      - replicated.saas.mysql:mysql
     ports:
       - "8090:5000"
     restart: always
@@ -24,6 +24,6 @@ services:
       - .:/usr/src/app
     command: [python, main.py]
 
-# networks:
-#   saas_default:
-#     external: true
+networks:
+  saas_default:
+    external: true

--- a/nginx-app.conf
+++ b/nginx-app.conf
@@ -1,27 +1,33 @@
 # mysite_nginx.conf
 
-# the upstream component nginx needs to connect to
-upstream flask {
-    server unix:/tmp/app.sock; # for a file socket
-    # server 127.0.0.1:8001; # for a web port socket (we'll use this first)
+events {
+    worker_connections 1024;
 }
 
-# configuration of the server
-server {
-    # the port your site will be served on, default_server indicates that this server block
-    # is the block to use if no blocks match the server_name
-    listen      80 default_server;
+http {
+  # the upstream component nginx needs to connect to
+  upstream flask {
+      server unix:/tmp/app.sock; # for a file socket
+      # server 127.0.0.1:8001; # for a web port socket (we'll use this first)
+  }
 
-    # the domain name it will serve for
-    server_name get.replicated.com; # substitute your machine's IP address or FQDN
-    charset     utf-8;
+  # configuration of the server
+  server {
+      # the port your site will be served on, default_server indicates that this server block
+      # is the block to use if no blocks match the server_name
+      listen      80 default_server;
 
-    # max upload size
-    client_max_body_size 75M;   # adjust to taste
+      # the domain name it will serve for
+      server_name get.replicated.com; # substitute your machine's IP address or FQDN
+      charset     utf-8;
 
-    # Finally, send all non-media requests to the Flask server.
-    location / {
-        uwsgi_pass  flask;
-        include     /home/docker/code/uwsgi_params; # the uwsgi_params file you installed
-    }
+      # max upload size
+      client_max_body_size 75M;   # adjust to taste
+
+      # Finally, send all non-media requests to the Flask server.
+      location / {
+          uwsgi_pass  flask;
+          include     /home/docker/code/uwsgi_params; # the uwsgi_params file you installed
+      }
+  }
 }

--- a/supervisor-app.conf
+++ b/supervisor-app.conf
@@ -6,4 +6,8 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:nginx-app]
-command = /usr/sbin/nginx
+command = /usr/local/nginx/sbin/nginx -g "daemon off;"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
* Builds `nginx` version `1.24.0` from source rather than installing from outdated APT or trying to update `python:2` to `python:3`
* Removes [EOL version of remote docker](https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176) in CircleCI

----

Locally, I can now see that `nginx version: nginx/1.24.0` is installed and that it responds when spun up:

```
$> docker run --rm -it ttl.sh/replicated/replicated-installer:1h bash -c "nginx -v"

nginx version: nginx/1.24.0
```

```
[Fri Oct 18 17:53:06 2024] GET /healthz => generated 0 bytes in 26 msecs (HTTP/1.1 200) 2 headers in 78 bytes (1 switches on core 0)
[Fri Oct 18 17:53:10 2024] GET /livez => generated 7963 bytes in 51 msecs (HTTP/1.1 200) 2 headers in 90 bytes (1 switches on core 0)
[Fri Oct 18 17:53:18 2024] GET /stable => generated 60511 bytes in 59 msecs (HTTP/1.1 200) 2 headers in 91 bytes (2 switches on core 0)
[Fri Oct 18 17:53:20 2024] GET /kubernetes-images.json => generated 1113 bytes in 6 msecs (HTTP/1.1 200) 2 headers in 73 bytes (1 switches on core 0)
[Fri Oct 18 17:53:24 2024] GET /kubernetes-images.json => generated 1113 bytes in 9 msecs (HTTP/1.1 200) 2 headers in 73 bytes (2 switches on core 0)
```

And it appears that builds / tests succeed. Since the standard PR workflow does not actually build `Dockerfile.prod`, I temporarily placed that Job in the Workflow to see that it would build correctly in CircleCI

<img width="1325" alt="Screenshot 2024-10-17 at 23 02 09" src="https://github.com/user-attachments/assets/e13795ac-02b5-4a11-a8ba-249eb7b274ee">
